### PR TITLE
Run yarn as production

### DIFF
--- a/ci/tasks/build.yml
+++ b/ci/tasks/build.yml
@@ -17,10 +17,10 @@ run:
     - |
       apk add zip
       cd src
-      yarn install && yarn build
+      yarn install --production && yarn build
 
       cd heartbeat-src
-      yarn install && yarn build
+      yarn install --production && yarn build
       cd ..
 
       cp dist/*.zip ../release-artefacts/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:alphagov/di-authentication-smoke-tests.git",
   "license": "MIT",
   "scripts": {
-    "build": "mkdir -p dist/nodejs/node_modules && cp -rf src/* dist/nodejs/node_modules/ && cp -rf node_modules/* dist/nodejs/node_modules/ && cd dist && zip -r canary.zip nodejs",
+    "build": "mkdir -p dist/nodejs/node_modules && cp -rf src/* dist/nodejs/node_modules/ && cd dist && zip -r canary.zip nodejs",
     "pretty": "prettier --write \"*/**/*.{js,json}\"",
     "lint": "eslint . --ext .js"
   },


### PR DESCRIPTION
Only install production assets as the rest of the packages are already installed.