### PR TITLE
Govsi 848 - update s3 permissions

### DIFF
--- a/ci/terraform/policies.tf
+++ b/ci/terraform/policies.tf
@@ -85,6 +85,7 @@ data "aws_iam_policy_document" "sms_bucket_policy" {
     actions = [
       "s3:DeleteObject",
       "s3:ListObjects",
+      "s3:ListBucket",
     ]
 
     resources = [


### PR DESCRIPTION
Update s3 permissions to allow clearing of sms code bucket.