### PR TITLE
AUTH-1251: Remove redundant resources

### DIFF
--- a/ci/terraform/alerts.tf
+++ b/ci/terraform/alerts.tf
@@ -41,11 +41,6 @@ resource "aws_iam_role_policy_attachment" "alerts_execution" {
   role       = aws_iam_role.alerts_execution.name
 }
 
-resource "aws_iam_role_policy_attachment" "sns_execution" {
-  policy_arn = aws_iam_policy.slack_sns_policy.arn
-  role       = aws_iam_role.alerts_execution.name
-}
-
 resource "aws_iam_role_policy_attachment" "parameter_execution" {
   policy_arn = aws_iam_policy.parameter_policy.arn
   role       = aws_iam_role.alerts_execution.name
@@ -70,36 +65,6 @@ resource "aws_lambda_function" "alerts_lambda" {
   runtime = "nodejs14.x"
 
   tags = local.default_tags
-}
-
-data "aws_iam_policy_document" "slack_sns_policy_document" {
-  version   = "2012-10-17"
-  policy_id = "${var.environment}-slack-sns-topic-policy"
-
-  statement {
-    effect = "Allow"
-    sid    = "GiveSlackSnsTopicPolicyPublish"
-    actions = [
-      "SNS:Publish",
-      "SNS:RemovePermission",
-      "SNS:SetTopicAttributes",
-      "SNS:DeleteTopic",
-      "SNS:ListSubscriptionsByTopic",
-      "SNS:GetTopicAttributes",
-      "SNS:Receive",
-      "SNS:AddPermission",
-      "SNS:Subscribe"
-    ]
-    resources = [data.aws_sns_topic.slack_events.arn]
-  }
-}
-
-resource "aws_iam_policy" "slack_sns_policy" {
-  name        = "${var.environment}-slack-lambda-sns-policy"
-  path        = "/"
-  description = "IAM policy for managing Slack SNS connection for a lambda"
-
-  policy = data.aws_iam_policy_document.slack_sns_policy_document.json
 }
 
 resource "aws_sns_topic_subscription" "event_stream_subscription" {

--- a/ci/terraform/pagerduty.tf
+++ b/ci/terraform/pagerduty.tf
@@ -9,11 +9,6 @@ resource "aws_sns_topic" "pagerduty_p2_alerts" {
   tags = local.default_tags
 }
 
-resource "aws_sns_topic" "pagerduty_cronitor_alerts" {
-  name = "${var.environment}-pagerduty-cronitor-alerts"
-  tags = local.default_tags
-}
-
 data "aws_iam_policy_document" "pagerduty_alerts_policy_document" {
   version   = "2012-10-17"
   policy_id = "${var.environment}-pagerduty-alerts-sns-topic-policy"
@@ -32,7 +27,7 @@ data "aws_iam_policy_document" "pagerduty_alerts_policy_document" {
       "SNS:AddPermission",
       "SNS:Subscribe"
     ]
-    resources = [aws_sns_topic.pagerduty_p1_alerts.arn, aws_sns_topic.pagerduty_p2_alerts.arn, aws_sns_topic.pagerduty_cronitor_alerts.arn]
+    resources = [aws_sns_topic.pagerduty_p1_alerts.arn, aws_sns_topic.pagerduty_p2_alerts.arn]
   }
 }
 
@@ -50,34 +45,3 @@ resource "aws_sns_topic_subscription" "pagerduty_p2_alerts_topic_subscription" {
   endpoint  = var.pagerduty_p2_alerts_endpoint
 }
 
-resource "aws_sns_topic_subscription" "pagerduty_cronitor_alerts_topic_subscription" {
-  count     = var.environment == "production" ? 1 : 0
-  topic_arn = aws_sns_topic.pagerduty_cronitor_alerts.arn
-  protocol  = "https"
-  endpoint  = var.pagerduty_cronitor_alerts_endpoint
-}
-
-resource "aws_cloudwatch_event_rule" "pagerduty_cronitor_alerts_event_rule" {
-  name       = "${var.environment}-pagerduty-cronitor-alerts-event-rule"
-  is_enabled = true
-  event_pattern = jsonencode({
-    "source" = [
-      "aws.synthetics"
-    ],
-    "detail-type" = [
-      "Synthetics Canary TestRun Failure"
-    ],
-    "detail" = {
-      "canary-name" : [
-        local.smoke_tester_name
-      ]
-    }
-  })
-
-  tags = local.default_tags
-}
-
-resource "aws_cloudwatch_event_target" "pagerduty_cronitor_alerts_event_target" {
-  arn  = aws_sns_topic.pagerduty_cronitor_alerts.arn
-  rule = aws_cloudwatch_event_rule.pagerduty_cronitor_alerts_event_rule.name
-}


### PR DESCRIPTION
## What?

- Remove the PagerDuty Cronitor SNS topic, and related resources, as they are not used
- The SNS policy being attached to the Slack alert lambda is unnecessary. The lambda does not need any SNS permissions, as the SNS runtime handles the passing of the message.

## Why?

Keeping the code clean and removing unnecessary permissions is a good thing.