### PR TITLE
AUTH-1250: Use shared artefact for alert and heartbeat

### DIFF
--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -24,11 +24,14 @@ params:
   PAGERDUTY_P2_ALERTS_ENDPOINT: ((pagerduty-p2-alerts-endpoint))
   PAGERDUTY_CRONITOR_ALERTS_ENDPOINT: ((pagerduty-cronitor-alerts-endpoint))
   SLACK_ALERT_URI: ((monitoring-alert-slack-webhook))
+  SIGNED_CODE_S3_BUCKET: ((di-auth-lambda-signed-bucket))
 
 inputs:
   - name: src
   - name: smoke-test-release
   - name: hashed-password
+  - name: di-monitoring-utils-alerts-lambda
+  - name: di-monitoring-utils-heartbeat-lambda
 outputs:
   - name: terraform-outputs
 run:
@@ -36,6 +39,9 @@ run:
   args:
     - -euc
     - |
+      ALERT_CODE_S3_KEY="di-monitoring-utils/alerts.zip/$(ls -1 di-monitoring-utils-alerts-lambda/signed-*.zip)"
+      HEARTBEAT_CODE_S3_KEY="di-monitoring-utils/heartbeat.zip/$(ls -1 di-monitoring-utils-heartbeat-lambda/signed-*.zip)"
+      
       cd "src/ci/terraform"
       terraform init -input=false \
         -backend-config "role_arn=${DEPLOYER_ROLE_ARN}" \
@@ -66,5 +72,8 @@ run:
         -var "smoke_test_lambda_zip_file=../../../smoke-test-release/canary.zip" \
         -var "alerts_lambda_zip_file=../../../smoke-test-release/alerts.zip" \
         -var "username=${SMOKETESTER_USERNAME}" \
+        -var "code_s3_bucket=${SIGNED_CODE_S3_BUCKET}" \
+        -var "alerts_code_s3_key=${ALERT_CODE_S3_KEY}" \
+        -var "heartbeat_code_s3_key=${HEARTBEAT_CODE_S3_KEY}" \
 
       terraform output --json > ../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-smoke-test-terraform-outputs.json

--- a/ci/terraform/alerts.tf
+++ b/ci/terraform/alerts.tf
@@ -47,9 +47,10 @@ resource "aws_iam_role_policy_attachment" "parameter_execution" {
 }
 
 resource "aws_lambda_function" "alerts_lambda" {
-  function_name    = local.alerts_lambda_name
-  filename         = var.alerts_lambda_zip_file
-  source_code_hash = filebase64sha256(var.alerts_lambda_zip_file)
+  function_name = local.alerts_lambda_name
+
+  s3_bucket = var.code_s3_bucket
+  s3_key    = var.alerts_code_s3_key
 
   role        = aws_iam_role.alerts_execution.arn
   handler     = "alerts.handler"

--- a/ci/terraform/heartbeat.tf
+++ b/ci/terraform/heartbeat.tf
@@ -42,9 +42,10 @@ resource "aws_iam_role_policy_attachment" "cronitor_execution" {
 }
 
 resource "aws_lambda_function" "cronitor_ping_lambda" {
-  function_name    = local.cronitor_lambda_name
-  filename         = var.heartbeat_lambda_zip_file
-  source_code_hash = filebase64sha256(var.heartbeat_lambda_zip_file)
+  function_name = local.cronitor_lambda_name
+
+  s3_bucket = var.code_s3_bucket
+  s3_key    = var.heartbeat_code_s3_key
 
   role        = aws_iam_role.cronitor_execution.arn
   handler     = "heartbeat.handler"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -108,3 +108,14 @@ variable "basic_auth_password" {
 variable "terms_and_conditions_version" {
   default = "1.1"
 }
+
+variable "code_s3_bucket" {
+  type = string
+}
+variable "alerts_code_s3_key" {
+  type = string
+}
+
+variable "heartbeat_code_s3_key" {
+  type = string
+}


### PR DESCRIPTION
## What?

- Update the Terraform to pick up the code direct from signed code bucket.

## Why?

We are now building the alert lambda and heartbeat lambda in a standalone repository and publishing signed ZIPs to an S3 bucket.

## Related PRs

https://github.com/alphagov/di-monitoring-utils/pull/2
https://github.com/alphagov/di-infrastructure/pull/207