### PR TITLE
AUTH-1250: Pass correct S3 key to Terraform

### DIFF
--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -39,8 +39,8 @@ run:
   args:
     - -euc
     - |
-      ALERT_CODE_S3_KEY="di-monitoring-utils/alerts.zip/$(ls -1 di-monitoring-utils-alerts-lambda/signed-*.zip)"
-      HEARTBEAT_CODE_S3_KEY="di-monitoring-utils/heartbeat.zip/$(ls -1 di-monitoring-utils-heartbeat-lambda/signed-*.zip)"
+      ALERT_CODE_S3_KEY="di-monitoring-utils/alerts.zip/$(basename $(ls -1 di-monitoring-utils-alerts-lambda/signed-*.zip))"
+      HEARTBEAT_CODE_S3_KEY="di-monitoring-utils/heartbeat.zip/$(basename $(ls -1 di-monitoring-utils-heartbeat-lambda/signed-*.zip))"
       
       cd "src/ci/terraform"
       terraform init -input=false \


### PR DESCRIPTION
## What?

- Remove the Concourse resource name from the calculated S3 key (filename) as this results in an invalid S3 key.

## Why?

Pipeline is currently failing with "invalid key name" message.

## Related PRs

#41 