### PR TITLE
BAU: Stop clearing entire bucket

### DIFF
--- a/src/aws.js
+++ b/src/aws.js
@@ -15,16 +15,15 @@ const getParameter = async (parameterName) => {
   return result.Parameter.Value;
 };
 
-const emptyOtpBucket = async (bucketName) => {
-  const { Contents } = await S3.listObjectsV2({ Bucket: bucketName }).promise();
-  if (Contents.length > 0) {
+const emptyOtpBucket = async (bucketName, phoneNumber) => {
     await S3.deleteObjects({
       Bucket: bucketName,
       Delete: {
-        Objects: Contents.map(({ Key }) => ({ Key })),
+        Objects: [
+            phoneNumber
+        ],
       },
     }).promise();
-  }
 };
 
 const getOTPCode = async (phoneNumber, bucketName) => {

--- a/src/canary.js
+++ b/src/canary.js
@@ -15,9 +15,10 @@ const basicCustomEntryPoint = async () => {
   log.info("Running smoke tests");
 
   const bucketName = await getParameter("bucket");
+  const phoneNumber = await getParameter("phone");
 
   log.info("Empty OTP code bucket");
-  await emptyOtpBucket(bucketName);
+  await emptyOtpBucket(bucketName, phoneNumber);
 
   let page = await synthetics.getPage();
   const navigationPromise = page.waitForNavigation({
@@ -86,7 +87,6 @@ const basicCustomEntryPoint = async () => {
   await synthetics.executeStep("Enter OTP code", async () => {
     await page.waitForSelector(".govuk-grid-row #code");
 
-    const phoneNumber = await getParameter("phone");
     const otpCode = await getOTPCode(phoneNumber, bucketName);
 
     await page.type(".govuk-grid-row #code", otpCode);


### PR DESCRIPTION
## What?

- Only delete the file for the phone number allocated to these tests

## Why?

Clearing the entire bucket is no longer acceptable as other processes are using the bucket to pick up the SMS codes from.
