### PR TITLE
BAU: Use `DeleteObject` instead of `DeleteObjects`

### DIFF
--- a/src/aws.js
+++ b/src/aws.js
@@ -16,13 +16,9 @@ const getParameter = async (parameterName) => {
 };
 
 const emptyOtpBucket = async (bucketName, phoneNumber) => {
-    await S3.deleteObjects({
+    await S3.deleteObject({
       Bucket: bucketName,
-      Delete: {
-        Objects: [
-            phoneNumber
-        ],
-      },
+      Key: phoneNumber
     }).promise();
 };
 


### PR DESCRIPTION
## What?

- Simplify call to delete file from bucket by using the `DeleteObject` API call rather than `DeleteObjects` as we're only deleting a single object

## Why?

Call to `DeleteObjects` is failing due to invalid parameter being passed. Using `DeleteObject` makes more sense anyway as we're only deleting a single object.

## Related PRs

#44 