### PR TITLE
BAU: Change expected page title on account management page

### DIFF
--- a/src/canary.js
+++ b/src/canary.js
@@ -107,7 +107,7 @@ const basicCustomEntryPoint = async () => {
     await page.waitForSelector("#warning-link");
 
     const hasReachedAM =
-      (await page.title()) === "Manage your account - GOV.UK account";
+      (await page.title()) === "Your GOV.UK account - GOV.UK account";
 
     if (!hasReachedAM) {
       throw "Failed smoke test";


### PR DESCRIPTION
## What?

- Change expected page title on account management page to "Your GOV.UK account - GOV.UK account"

## Why?

A change has recently been put through that has changed the title of the account managment pages.

## Related PRs

https://github.com/alphagov/di-authentication-account-management/pull/502