### PR TITLE
BAU: Change the known selector to wait for in account management

### DIFF
--- a/src/canary.js
+++ b/src/canary.js
@@ -104,7 +104,7 @@ const basicCustomEntryPoint = async () => {
   await navigationPromise;
 
   await synthetics.executeStep("Manage your account", async () => {
-    await page.waitForSelector("#warning-link");
+    await page.waitForSelector("#your-account");
 
     const hasReachedAM =
       (await page.title()) === "Your GOV.UK account - GOV.UK account";


### PR DESCRIPTION
## What?

- Change the ID to wait for to `#your-account`

## Why?

The `#warning-link` ID has been removed in a recent change

## Related PRs

https://github.com/alphagov/di-authentication-account-management/pull/522