### PR TITLE
ACI-110 - Upgrade syn-nodejs-puppeteer version to the latest 3.8

### DIFF
--- a/ci/terraform/canary.tf
+++ b/ci/terraform/canary.tf
@@ -29,7 +29,7 @@ resource "aws_synthetics_canary" "smoke_tester" {
   execution_role_arn   = aws_iam_role.smoke_tester_role.arn
   handler              = "canary.handler"
   name                 = local.smoke_tester_name
-  runtime_version      = "syn-nodejs-puppeteer-3.3"
+  runtime_version      = "syn-nodejs-puppeteer-3.8"
   start_canary         = true
 
   s3_bucket  = aws_s3_bucket_object.canary_source.bucket


### PR DESCRIPTION
## What?

- Upgrade syn-nodejs-puppeteer version to the latest 3.8

## Why?

- Our current version is deprecated on November 13th 2022 so we should upgrade to 3.8.
- This has been tested in the Integration smoke tests but upgrading the version directly in the console and it seems to be happy.
