### PR TITLE
AUT-829: Wire alerts for create account smoketest

### DIFF
--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -19,6 +19,10 @@ module "canary_create_account" {
 
   account_management_url = local.account_management_url
 
+  sns_topic_pagerduty_p1_alerts_arn = aws_sns_topic.pagerduty_p1_alerts.arn
+  sns_topic_pagerduty_p2_alerts_arn = aws_sns_topic.pagerduty_p2_alerts.arn
+  sns_topic_slack_alerts_arn        = data.aws_sns_topic.slack_events.arn
+
   username            = var.username_create_account
   phone               = var.phone
   basic_auth_username = var.basic_auth_username

--- a/ci/terraform/modules/canary/alarm.tf
+++ b/ci/terraform/modules/canary/alarm.tf
@@ -1,0 +1,42 @@
+
+resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p1" {
+  count               = var.environment == "production" ? 0 : 1
+  alarm_name          = "${local.smoke_tester_name}-metric-alarm_p1"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Failed"
+  namespace           = "CloudWatchSynthetics"
+  period              = "600"
+  statistic           = "Sum"
+  threshold           = "3"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    CanaryName = aws_synthetics_canary.smoke_tester_canary[0].name
+  }
+
+  alarm_description = "GOV.UK Sign in - ${local.smoke_tester_name} P1 failure"
+  alarm_actions     = [var.environment == "production" ? var.sns_topic_pagerduty_p1_alerts_arn : var.sns_topic_slack_alerts_arn]
+  ok_actions        = [var.environment == "production" ? var.sns_topic_pagerduty_p1_alerts_arn : var.sns_topic_slack_alerts_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p2" {
+  count               = var.environment == "production" ? 0 : 1
+  alarm_name          = "${local.smoke_tester_name}-metric-alarm_p2"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "Failed"
+  namespace           = "CloudWatchSynthetics"
+  period              = "600"
+  statistic           = "Sum"
+  threshold           = "5"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    CanaryName = aws_synthetics_canary.smoke_tester_canary[0].name
+  }
+
+  alarm_description = "GOV.UK Sign in - ${local.smoke_tester_name} P2 failure"
+  alarm_actions     = [var.environment == "production" ? var.sns_topic_pagerduty_p2_alerts_arn : var.sns_topic_slack_alerts_arn]
+  ok_actions        = [var.environment == "production" ? var.sns_topic_pagerduty_p2_alerts_arn : var.sns_topic_slack_alerts_arn]
+}

--- a/ci/terraform/modules/canary/variables.tf
+++ b/ci/terraform/modules/canary/variables.tf
@@ -66,3 +66,15 @@ variable "basic_auth_username" {
 variable "basic_auth_password" {
   type = string
 }
+
+variable "sns_topic_pagerduty_p1_alerts_arn" {
+  type = string
+}
+
+variable "sns_topic_pagerduty_p2_alerts_arn" {
+  type = string
+}
+
+variable "sns_topic_slack_alerts_arn" {
+  type = string
+}


### PR DESCRIPTION
## What?

Wire alerts for create account smoketest.

- Create P1 and P2 alarms that post to the existing sns topics for PagerDuty and Slack.
- Alarms created in integration only, not production

## Why?

Alerts should be fired when the create account smoke test fails.

## Related PRs

#52 
