### PR TITLE
AUT-829: Add smoke test fire drill switch

### DIFF
--- a/ci/terraform/modules/canary/parameters.tf
+++ b/ci/terraform/modules/canary/parameters.tf
@@ -38,6 +38,14 @@ resource "aws_kms_alias" "parameter_store_key_alias" {
   target_key_id = aws_kms_key.parameter_store_key.id
 }
 
+resource "aws_ssm_parameter" "fire_drill" {
+  name  = "${var.environment}-${var.canary_name}-fire-drill"
+  type  = "String"
+  value = var.fire_drill
+
+  tags = local.default_tags
+}
+
 resource "aws_ssm_parameter" "base_url" {
   name  = "${var.environment}-${var.canary_name}-url"
   type  = "String"

--- a/ci/terraform/modules/canary/policies.tf
+++ b/ci/terraform/modules/canary/policies.tf
@@ -112,6 +112,7 @@ data "aws_iam_policy_document" "parameter_policy" {
     ]
 
     resources = [
+      aws_ssm_parameter.fire_drill.arn,
       aws_ssm_parameter.base_url.arn,
       aws_ssm_parameter.phone.arn,
       aws_ssm_parameter.sms_bucket.arn,

--- a/ci/terraform/modules/canary/variables.tf
+++ b/ci/terraform/modules/canary/variables.tf
@@ -47,6 +47,11 @@ variable "sms_bucket_name" {
   type = string
 }
 
+variable "fire_drill" {
+  type    = string
+  default = "0"
+}
+
 variable "account_management_url" {
   type = string
 }

--- a/src/canary-create-account.js
+++ b/src/canary-create-account.js
@@ -16,9 +16,15 @@ const basicCustomEntryPoint = async () => {
   log.info("Running smoke tests");
 
   const bucketName = await getParameter("bucket");
+  const fireDrill = await getParameter("fire-drill");
   const email = await getParameter("username");
   const phoneNumber = await getParameter("phone");
   const password = crypto.randomBytes(20).toString("base64url");
+
+  if (fireDrill === "1") {
+    log.info("Fire Drill! Smoke test will fail.");
+    throw "Smoke Test failed due to Fire Drill";
+  }
 
   log.info("Empty OTP code bucket");
   await emptyOtpBucket(bucketName, email);
@@ -234,9 +240,5 @@ const basicCustomEntryPoint = async () => {
 };
 
 module.exports.handler = async () => {
-  try {
     return await basicCustomEntryPoint();
-  } catch (err) {
-    log.error(err);
-  }
 };


### PR DESCRIPTION

## What?

Add smoke test fire drill switch.  Adds an SSM parameter that causes the create account smoke test to fail when set to '1'. 

Remove try catch block wrapped around the canary handler method.

## Why?

Provides facility to test that alerts are sent when the smoke test fails.
The try catch block was stopping the canary from actually failing when an error was thrown, instead it would log an error but not actually fail

## Related PRs

#52 