### PR TITLE
AUT-829: Call synthetics-user delete from the create account smoke test

### DIFF
--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -18,6 +18,9 @@ params:
   BASIC_AUTH_USERNAME: ((basic-auth-username-integration))
   BASIC_AUTH_PASSWORD: ((basic-auth-password-integration))
   SMOKETESTER_CREATE_ACCOUNT_USERNAME: ((smoke-tester-create-account-username-integration))
+  TEST_SERVICES_API_HOSTNAME: ((test-services-api-hostname-integration))
+  TEST_SERVICES_API_KEY: ((test-services-api-key-integration))
+  SYNTHETICS_USER_DELETE_PATH: ((synthetics-user-delete-path-integration))
   STATE_BUCKET: digital-identity-dev-tfstate
   CRONITOR_API_KEY: ((cronitor-send-events-api-key))
   CRONITOR_MONITOR_KEY: ((cronitor-monitor-key-integration))
@@ -75,5 +78,8 @@ run:
         -var "alerts_code_s3_key=${ALERT_CODE_S3_KEY}" \
         -var "heartbeat_code_s3_key=${HEARTBEAT_CODE_S3_KEY}" \
         -var "username_create_account=${SMOKETESTER_CREATE_ACCOUNT_USERNAME}" \
+        -var "test-services-api-hostname=${TEST_SERVICES_API_HOSTNAME}" \
+        -var "test-services-api-key=${TEST_SERVICES_API_KEY}" \
+        -var "synthetics-user-delete-path=${SYNTHETICS_USER_DELETE_PATH}" \
 
       terraform output --json > ../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-smoke-test-terraform-outputs.json

--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -23,11 +23,14 @@ module "canary_create_account" {
   sns_topic_pagerduty_p2_alerts_arn = aws_sns_topic.pagerduty_p2_alerts.arn
   sns_topic_slack_alerts_arn        = data.aws_sns_topic.slack_events.arn
 
-  username            = var.username_create_account
-  phone               = var.phone
-  basic_auth_username = var.basic_auth_username
-  basic_auth_password = var.basic_auth_password
+  test-services-api-key       = var.test-services-api-key
+  test-services-api-hostname  = var.test-services-api-hostname
+  synthetics-user-delete-path = var.synthetics-user-delete-path
+  username                    = var.username_create_account
+  phone                       = var.phone
+  basic_auth_username         = var.basic_auth_username
+  basic_auth_password         = var.basic_auth_password
 
-  smoke_test_cron_expression = "0/10 10-17 ? * MON-FRI *"
+  smoke_test_cron_expression = "0/05 10-17 ? * MON-FRI *"
 
 }

--- a/ci/terraform/modules/canary/parameters.tf
+++ b/ci/terraform/modules/canary/parameters.tf
@@ -46,6 +46,31 @@ resource "aws_ssm_parameter" "fire_drill" {
   tags = local.default_tags
 }
 
+resource "aws_ssm_parameter" "test-services-api-key" {
+  name  = "${var.environment}-${var.canary_name}-test-services-api-key"
+  type  = "String"
+  value = var.test-services-api-key
+
+  tags = local.default_tags
+}
+
+resource "aws_ssm_parameter" "test-services-api-hostname" {
+  name  = "${var.environment}-${var.canary_name}-test-services-api-hostname"
+  type  = "String"
+  value = var.test-services-api-hostname
+
+  tags = local.default_tags
+}
+
+resource "aws_ssm_parameter" "synthetics-user-delete-path" {
+  name  = "${var.environment}-${var.canary_name}-synthetics-user-delete-path"
+  type  = "String"
+  value = var.synthetics-user-delete-path
+
+  tags = local.default_tags
+}
+
+
 resource "aws_ssm_parameter" "base_url" {
   name  = "${var.environment}-${var.canary_name}-url"
   type  = "String"

--- a/ci/terraform/modules/canary/policies.tf
+++ b/ci/terraform/modules/canary/policies.tf
@@ -113,6 +113,9 @@ data "aws_iam_policy_document" "parameter_policy" {
 
     resources = [
       aws_ssm_parameter.fire_drill.arn,
+      aws_ssm_parameter.test-services-api-key.arn,
+      aws_ssm_parameter.test-services-api-hostname.arn,
+      aws_ssm_parameter.synthetics-user-delete-path.arn,
       aws_ssm_parameter.base_url.arn,
       aws_ssm_parameter.phone.arn,
       aws_ssm_parameter.sms_bucket.arn,

--- a/ci/terraform/modules/canary/variables.tf
+++ b/ci/terraform/modules/canary/variables.tf
@@ -52,6 +52,18 @@ variable "fire_drill" {
   default = "0"
 }
 
+variable "synthetics-user-delete-path" {
+  type = string
+}
+
+variable "test-services-api-key" {
+  type = string
+}
+
+variable "test-services-api-hostname" {
+  type = string
+}
+
 variable "account_management_url" {
   type = string
 }

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -112,3 +112,15 @@ variable "heartbeat_code_s3_key" {
 variable "username_create_account" {
   type = string
 }
+
+variable "synthetics-user-delete-path" {
+  type = string
+}
+
+variable "test-services-api-key" {
+  type = string
+}
+
+variable "test-services-api-hostname" {
+  type = string
+}


### PR DESCRIPTION
## What?

Call synthetics-user delete from the create account smoke test.

- Add additional config for the test-services api synthetics-user endpoint.
- Call the endpoint at the beginning of the create account smoke test so that the test does not try to create an existing user.
- Remove the step to delete the account in Account Management.

This canary is currently running in integration only.

## Why?

To delete the user create by previous test runs.
Removes the dependency on Account Management to clean up the created test user.

## Related PRs

#52 
#54 
