### PR TITLE
AUT-829: Update canary name and alarm descriptions

### DIFF
--- a/ci/terraform/alarm.tf
+++ b/ci/terraform/alarm.tf
@@ -14,7 +14,7 @@ resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p1" {
     CanaryName = aws_synthetics_canary.smoke_tester.name
   }
 
-  alarm_description = "GOV.UK Sign in - ${local.smoke_tester_name} P1 failure"
+  alarm_description = "GOV.UK Sign in - ${local.smoke_tester_name} (create account smoke test) P1 alarm"
   alarm_actions     = [var.environment == "production" ? aws_sns_topic.pagerduty_p1_alerts.arn : data.aws_sns_topic.slack_events.arn]
   ok_actions        = [var.environment == "production" ? aws_sns_topic.pagerduty_p1_alerts.arn : data.aws_sns_topic.slack_events.arn]
 }
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p2" {
     CanaryName = aws_synthetics_canary.smoke_tester.name
   }
 
-  alarm_description = "GOV.UK Sign in - ${local.smoke_tester_name} P2 failure"
+  alarm_description = "GOV.UK Sign in - ${local.smoke_tester_name} (create account smoke test) P2 alarm"
   alarm_actions     = [var.environment == "production" ? aws_sns_topic.pagerduty_p2_alerts.arn : data.aws_sns_topic.slack_events.arn]
   ok_actions        = [var.environment == "production" ? aws_sns_topic.pagerduty_p2_alerts.arn : data.aws_sns_topic.slack_events.arn]
 }

--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -11,7 +11,7 @@ module "canary_create_account" {
   sms_bucket_name_arn = local.sms_bucket_name_arn
 
   canary_handler = "canary-create-account.handler"
-  canary_name    = "create"
+  canary_name    = "smoke-cra"
 
   canary_source_bucket     = aws_s3_bucket_object.canary_source.bucket
   canary_source_key        = aws_s3_bucket_object.canary_source.key

--- a/ci/terraform/modules/canary/canary.tf
+++ b/ci/terraform/modules/canary/canary.tf
@@ -4,7 +4,7 @@ resource "aws_synthetics_canary" "smoke_tester_canary" {
   count                = var.environment == "production" ? 0 : 1
   artifact_s3_location = var.artifact_s3_location
 
-  execution_role_arn = aws_iam_role.smoke_tester_role.arn
+  execution_role_arn = aws_iam_role.smoke_tester_role[0].arn
   handler            = var.canary_handler
   name               = local.smoke_tester_name
   runtime_version    = "syn-nodejs-puppeteer-3.8"

--- a/ci/terraform/modules/canary/policies.tf
+++ b/ci/terraform/modules/canary/policies.tf
@@ -90,9 +90,7 @@ data "aws_iam_policy_document" "sms_bucket_policy" {
 
     resources = [
       var.sms_bucket_name_arn,
-      "${var.sms_bucket_name_arn}/*",
-      "arn:aws:s3:::build-smoke-test-sms-codes/*",
-      "arn:aws:s3:::build-smoke-test-sms-codes"
+      "${var.sms_bucket_name_arn}/*"
     ]
   }
 }

--- a/ci/terraform/modules/canary/roles.tf
+++ b/ci/terraform/modules/canary/roles.tf
@@ -1,26 +1,27 @@
 
 resource "aws_iam_role" "smoke_tester_role" {
+  count              = var.environment == "production" ? 0 : 1
   assume_role_policy = data.aws_iam_policy_document.lambda_can_assume_policy.json
   name               = "${var.environment}-${var.canary_name}-canary-execution-role"
 }
 
 resource "aws_iam_role_policy_attachment" "canary_execution" {
   policy_arn = aws_iam_policy.canary_execution.arn
-  role       = aws_iam_role.smoke_tester_role.name
+  role       = aws_iam_role.smoke_tester_role[0].name
 }
 
 resource "aws_iam_role_policy_attachment" "sms_bucket_policy" {
   policy_arn = aws_iam_policy.sms_bucket_policy.arn
-  role       = aws_iam_role.smoke_tester_role.name
+  role       = aws_iam_role.smoke_tester_role[0].name
 }
 
 resource "aws_iam_role_policy_attachment" "parameter_policy" {
   policy_arn = aws_iam_policy.parameter_policy.arn
-  role       = aws_iam_role.smoke_tester_role.name
+  role       = aws_iam_role.smoke_tester_role[0].name
 }
 
 resource "aws_iam_role_policy_attachment" "basic_auth_parameter_policy" {
   count      = var.environment == "production" ? 0 : 1
   policy_arn = aws_iam_policy.basic_auth_parameter_policy[0].arn
-  role       = aws_iam_role.smoke_tester_role.name
+  role       = aws_iam_role.smoke_tester_role[0].name
 }


### PR DESCRIPTION
## What?

Update canary name and alarm descriptions.
Tidy up bucket policy.

## Why?

Provide more meaningful information in alert messages.
Canary names cannot exceed 21 characters so extra information added to the alert for more context.
Remove rights to an enivronment specific bucket in the bucket policy.
