### PR TITLE
AUT-829: Fix prod smoke test deployment

### DIFF
--- a/ci/terraform/modules/canary/roles.tf
+++ b/ci/terraform/modules/canary/roles.tf
@@ -6,16 +6,19 @@ resource "aws_iam_role" "smoke_tester_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "canary_execution" {
+  count      = var.environment == "production" ? 0 : 1
   policy_arn = aws_iam_policy.canary_execution.arn
   role       = aws_iam_role.smoke_tester_role[0].name
 }
 
 resource "aws_iam_role_policy_attachment" "sms_bucket_policy" {
+  count      = var.environment == "production" ? 0 : 1
   policy_arn = aws_iam_policy.sms_bucket_policy.arn
   role       = aws_iam_role.smoke_tester_role[0].name
 }
 
 resource "aws_iam_role_policy_attachment" "parameter_policy" {
+  count      = var.environment == "production" ? 0 : 1
   policy_arn = aws_iam_policy.parameter_policy.arn
   role       = aws_iam_role.smoke_tester_role[0].name
 }


### PR DESCRIPTION

## What?

Fix prod smoke test deployment.

Add counts to policies not having a parent in prod.


## Why?

Terraform apply has failed as a previous PR added a 'count' = 0 to the 'smoke_tester_role' in prod without adding a corresponding 'count' to child policies.

## Related PRs

#57 
