### PR TITLE
AUT-834: Fix smoke test microclient race condition

### DIFF
--- a/src/canary-create-account.js
+++ b/src/canary-create-account.js
@@ -263,12 +263,13 @@ const basicCustomEntryPoint = async () => {
     await page.waitForSelector(
       "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button"
     );
-    await page.click(
-      "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button"
+      await Promise.all([
+        page.click(
+              "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button",
+        page.waitForNavigation(),
+      ]);
     );
   });
-
-  await navigationPromise;
 
   await synthetics.executeStep("Microclient user-info", async () => {
     await page.content();


### PR DESCRIPTION
## What?

Fix smoke test microclient race condition.

## Why?

Callback to the microclient had been failing roughly 50% of the time.  This was due to a race condition waiting for the various redirects to complete before the call to user-info could succeed.

See the 'Remarks' section:

https://pptr.dev/next/api/puppeteer.page.click

## Related PRs

#61 
