### PR TITLE
AUT-834: Add production smoke test client configuration

### DIFF
--- a/ci/terraform/production-overrides.tfvars
+++ b/ci/terraform/production-overrides.tfvars
@@ -1,0 +1,1 @@
+issuer_base_url = "https://oidc.account.gov.uk"

--- a/ci/terraform/production-stub-clients.tfvars
+++ b/ci/terraform/production-stub-clients.tfvars
@@ -1,0 +1,20 @@
+stub_rp_clients = [
+  {
+    client_name = "di-auth-smoketest-microclient-production"
+    callback_urls = [
+      "http://localhost:3031/callback",
+    ]
+    logout_urls = [
+      "http://localhost:3031/signed-out",
+    ]
+    test_client                     = "1"
+    consent_required                = "0"
+    identity_verification_supported = "0"
+    client_type                     = "web"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
+  },
+]


### PR DESCRIPTION
## What?

Add production smoke test client configuration.

## Why?

The existing smoke test will be switched to use the new client.
Creating the configuration now as the pipeline deploy task now requires these files in order to run.  Fixes broken pipeline.

## Related PRs

#61 
