### PR TITLE
AUT-834: Remove AM dependency from sign in smoketest

### DIFF
--- a/ci/terraform/parameters.tf
+++ b/ci/terraform/parameters.tf
@@ -109,3 +109,36 @@ resource "aws_ssm_parameter" "slack_hook_url" {
 
   tags = local.default_tags
 }
+
+resource "aws_ssm_parameter" "client_id" {
+  name  = "${local.smoke_tester_name}-client-id"
+  type  = "String"
+  value = random_string.stub_rp_client_id[0].result
+
+  tags = local.default_tags
+}
+
+resource "aws_ssm_parameter" "client_private_key" {
+  name   = "${local.smoke_tester_name}-client-private-key"
+  type   = "SecureString"
+  value  = tls_private_key.stub_rp_client_private_key[0].private_key_pem
+  key_id = aws_kms_alias.parameter_store_key_alias.id
+
+  tags = local.default_tags
+}
+
+resource "aws_ssm_parameter" "client_base_url" {
+  name  = "${local.smoke_tester_name}-client-base-url"
+  type  = "String"
+  value = var.client_base_url
+
+  tags = local.default_tags
+}
+
+resource "aws_ssm_parameter" "issuer_base_url" {
+  name  = "${local.smoke_tester_name}-issuer-base-url"
+  type  = "String"
+  value = var.issuer_base_url
+
+  tags = local.default_tags
+}

--- a/ci/terraform/policies.tf
+++ b/ci/terraform/policies.tf
@@ -116,6 +116,10 @@ data "aws_iam_policy_document" "parameter_policy" {
       aws_ssm_parameter.sms_bucket.arn,
       aws_ssm_parameter.username.arn,
       aws_ssm_parameter.slack_hook_url.arn,
+      aws_ssm_parameter.client_id.arn,
+      aws_ssm_parameter.client_base_url.arn,
+      aws_ssm_parameter.issuer_base_url.arn,
+      aws_ssm_parameter.client_private_key.arn,
     ]
   }
   statement {


### PR DESCRIPTION
## What?

Remove AM dependency from sign in smoketest.
Use the microclient instead.
Some linting and formatting changes.
Remove try catch block from the handler wrapper as this suppresses canary failures in some circumstances.

This will initially be rolled-out to integration only with the prod deploy job paused to stop it deploying to prod.

## Why?

Removing all Auth dependencies on Account Management as the team no longer owns the app.

## Related PRs

#61 
#64 