### PR TITLE
AUT-834: Add smoke test global ssm parameter for client id

### DIFF
--- a/ci/terraform/parameters.tf
+++ b/ci/terraform/parameters.tf
@@ -109,3 +109,11 @@ resource "aws_ssm_parameter" "slack_hook_url" {
 
   tags = local.default_tags
 }
+
+resource "aws_ssm_parameter" "smoke_test_client_id" {
+  name  = "${var.environment}-smoke-test-client-id"
+  type  = "String"
+  value = random_string.stub_rp_client_id[0].result
+
+  tags = local.default_tags
+}


### PR DESCRIPTION
## What?

Add smoke test global ssm parameter for client id.

## Why?

This parameter will be consumed by the oidc api waf configuration.
