### PR TITLE
AUT-829: Ensure password contains letters and numbers

### DIFF
--- a/src/canary-create-account.js
+++ b/src/canary-create-account.js
@@ -47,7 +47,7 @@ const basicCustomEntryPoint = async () => {
 
   const email = await getParameter("username");
   const phoneNumber = await getParameter("phone");
-  const password = crypto.randomBytes(20).toString("base64url");
+  const password = crypto.randomBytes(20).toString("base64url") + "a1";
   const clientId = await getParameter("client-id");
   const clientBaseUrl = await getParameter("client-base-url");
   const issuerBaseURL = await getParameter("issuer-base-url");


### PR DESCRIPTION
## What?

Ensure password contains letters and numbers by adding 'a1' to the end of the random password.

This smoke test (create account) is currently only running in integration.

## Why?

On its own 'crypto.randomBytes' is able to generate passwords that do not contain both letters and numbers.
