### PR TITLE
AUT-834: Remove AM dependency from sign in smoketest

### DIFF
--- a/ci/terraform/parameters.tf
+++ b/ci/terraform/parameters.tf
@@ -117,3 +117,35 @@ resource "aws_ssm_parameter" "smoke_test_client_id" {
 
   tags = local.default_tags
 }
+resource "aws_ssm_parameter" "client_id" {
+  name  = "${local.smoke_tester_name}-client-id"
+  type  = "String"
+  value = random_string.stub_rp_client_id[0].result
+
+  tags = local.default_tags
+}
+
+resource "aws_ssm_parameter" "client_private_key" {
+  name   = "${local.smoke_tester_name}-client-private-key"
+  type   = "SecureString"
+  value  = tls_private_key.stub_rp_client_private_key[0].private_key_pem
+  key_id = aws_kms_alias.parameter_store_key_alias.id
+
+  tags = local.default_tags
+}
+
+resource "aws_ssm_parameter" "client_base_url" {
+  name  = "${local.smoke_tester_name}-client-base-url"
+  type  = "String"
+  value = var.client_base_url
+
+  tags = local.default_tags
+}
+
+resource "aws_ssm_parameter" "issuer_base_url" {
+  name  = "${local.smoke_tester_name}-issuer-base-url"
+  type  = "String"
+  value = var.issuer_base_url
+
+  tags = local.default_tags
+}

--- a/ci/terraform/policies.tf
+++ b/ci/terraform/policies.tf
@@ -116,6 +116,10 @@ data "aws_iam_policy_document" "parameter_policy" {
       aws_ssm_parameter.sms_bucket.arn,
       aws_ssm_parameter.username.arn,
       aws_ssm_parameter.slack_hook_url.arn,
+      aws_ssm_parameter.client_id.arn,
+      aws_ssm_parameter.client_base_url.arn,
+      aws_ssm_parameter.issuer_base_url.arn,
+      aws_ssm_parameter.client_private_key.arn,
     ]
   }
   statement {

--- a/src/canary.js
+++ b/src/canary.js
@@ -1,6 +1,7 @@
 const log = require("SyntheticsLogger");
 const synthetics = require("Synthetics");
 const { getParameter, getOTPCode, emptyOtpBucket } = require("./aws");
+const { startClient } = require("./client");
 
 const CANARY_NAME = synthetics.getCanaryName();
 const SYNTHETICS_CONFIG = synthetics.getConfiguration();
@@ -17,6 +18,19 @@ const basicCustomEntryPoint = async () => {
   const bucketName = await getParameter("bucket");
   const email = await getParameter("username");
   const phoneNumber = await getParameter("phone");
+  const clientBaseUrl = await getParameter("client-base-url");
+  const clientId = await getParameter("client-id");
+  const issuerBaseURL = await getParameter("issuer-base-url");
+  const clientPrivateKey = await getParameter("client-private-key");
+
+  const server = await startClient(
+    3031,
+    "openid email phone",
+    clientId,
+    clientBaseUrl,
+    issuerBaseURL,
+    clientPrivateKey
+  );
 
   log.info("Empty OTP code bucket");
   await emptyOtpBucket(bucketName, phoneNumber);
@@ -38,9 +52,10 @@ const basicCustomEntryPoint = async () => {
     });
   }
 
-  await synthetics.executeStep("Launch AM", async () => {
-    const url = await getParameter("url");
-    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });
+  await synthetics.executeStep("Launch Client", async () => {
+    await page.goto(clientBaseUrl, {
+      waitUntil: "domcontentloaded",
+    });
   });
 
   await page.setViewport({ width: 1864, height: 1096 });
@@ -99,31 +114,34 @@ const basicCustomEntryPoint = async () => {
     await page.waitForSelector(
       "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button"
     );
-    await page.click(
-      "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button"
-    );
+    await Promise.all([
+      page.click(
+        "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button"
+      ),
+      page.waitForNavigation(),
+    ]);
   });
 
-  await navigationPromise;
+  await synthetics.executeStep("Microclient user-info", async () => {
+    await page.content();
 
-  await synthetics.executeStep("Your services", async () => {
-    await page.waitForSelector(".govuk-header__logotype-text");
+    const userInfo = await page.evaluate(() => {
+      // eslint-disable-next-line no-undef
+      return JSON.parse(document.querySelector("body").innerText);
+    });
 
-    const hasReachedAM =
-      (await page.title()) === "Your services - GOV.UK account";
+    const hasReachedUserInfo = userInfo.email === email;
 
-    if (!hasReachedAM) {
+    if (!hasReachedUserInfo) {
+      server.close();
       throw "Failed smoke test";
     }
   });
 
+  server.close();
   return "success";
 };
 
 module.exports.handler = async () => {
-  try {
-    return await basicCustomEntryPoint();
-  } catch (err) {
-    log.error(err);
-  }
+  return await basicCustomEntryPoint();
 };


### PR DESCRIPTION
## What?

Remove AM dependency from sign in smoketest.
Use the microclient instead.
Some linting and formatting changes.
Remove try catch block from the handler wrapper as this suppresses canary failures in some circumstances.

This will initially be rolled-out to integration only with the prod deploy job paused to stop it deploying to prod.
It's the second attempt to release following changes to the WAF to allow the microclient to authorize.

## Why?

Removing all Auth dependencies on Account Management as the team no longer owns the app.

## Related PRs

WAF updates: https://github.com/alphagov/di-authentication-api/pull/2709

#61 
#64 