### PR TITLE
AUT-835: Add default values for integration variables

### DIFF
--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -173,11 +173,13 @@ variable "use_integration_env_for_sign_in_journey" {
 
 variable "integration_issuer_base_url" {
   type        = string
+  default     = null
   description = "In some upstream environments e.g. sandpit, not all functionality may be enabled e.g. IPV. Sometimes we might therefore choose to use integration"
 
 }
 
 variable "integration_password" {
   type        = string
+  default     = null
   description = "In some upstream environments e.g. sandpit, not all functionality may be enabled e.g. IPV. Sometimes we might therefore choose to use integration"
 }


### PR DESCRIPTION
## What?

- Add default values for integration issuer base url and password

## Why?

- These are only used in sandpit so that it can 'point at' integration
- They are therefore not supplied for other environments

## Related PRs

- Amends: https://github.com/alphagov/di-authentication-smoke-tests/pull/74
