### PR TITLE
AUT-981 - Ship smoke test logs to Splunk

### DIFF
--- a/ci/terraform/canary-sign-in-with-ipv.tf
+++ b/ci/terraform/canary-sign-in-with-ipv.tf
@@ -40,4 +40,7 @@ module "canary_sign_in_with_ipv" {
   # the test will run Mon-Fri, between 1000-1700 every 5 minutes
   smoke_test_cron_expression = "0/05 10-17 ? * MON-FRI *"
 
+  cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention = 1
+  logging_endpoint_arns    = var.logging_endpoint_arns
 }

--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -40,4 +40,7 @@ module "canary_create_account" {
 
   smoke_test_cron_expression = "0/03 10-17 ? * MON-FRI *"
 
+  cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention = 1
+  logging_endpoint_arns    = var.logging_endpoint_arns
 }

--- a/ci/terraform/integration-overrides.tfvars
+++ b/ci/terraform/integration-overrides.tfvars
@@ -1,1 +1,5 @@
 issuer_base_url = "https://oidc.integration.account.gov.uk"
+
+logging_endpoint_arns = [
+  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+]

--- a/ci/terraform/modules/canary/variables.tf
+++ b/ci/terraform/modules/canary/variables.tf
@@ -129,3 +129,19 @@ variable "integration_issuer_base_url" {
 variable "client_private_key" {
   type = string
 }
+
+variable "cloudwatch_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key to use log encryption"
+}
+
+variable "cloudwatch_log_retention" {
+  type        = number
+  description = "The number of days to retain Cloudwatch logs for"
+}
+
+variable "logging_endpoint_arns" {
+  type        = list(string)
+  default     = []
+  description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
+}

--- a/ci/terraform/production-overrides.tfvars
+++ b/ci/terraform/production-overrides.tfvars
@@ -1,1 +1,5 @@
 issuer_base_url = "https://oidc.account.gov.uk"
+
+logging_endpoint_arns = [
+  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+]

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -29,3 +29,5 @@ heartbeat_code_s3_key                   = "di-monitoring-utils/heartbeat.zip/san
 hashed_password                         = "123456"
 code_s3_bucket                          = "sandpit-smoke-test-sms-codes"
 use_integration_env_for_sign_in_journey = true
+
+logging_endpoint_arns = []

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -183,3 +183,9 @@ variable "integration_password" {
   default     = null
   description = "In some upstream environments e.g. sandpit, not all functionality may be enabled e.g. IPV. Sometimes we might therefore choose to use integration"
 }
+
+variable "logging_endpoint_arns" {
+  type        = list(string)
+  default     = []
+  description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
+}


### PR DESCRIPTION
## What?

 - Ship smoke test logs to Splunk

## Why?

- Add a aws_cloudwatch_log_group and aws_cloudwatch_log_subscription_filter terraform resource to the canary.tf module. This will allow for smoke test resources to be sent to Splunk which will allow easier access to smoke test logs.
