### PR TITLE
AUT-835: Enable IPV/P2 journey smoke test in prod

### DIFF
--- a/ci/terraform/canary-sign-in-with-ipv.tf
+++ b/ci/terraform/canary-sign-in-with-ipv.tf
@@ -1,6 +1,5 @@
 module "canary_sign_in_with_ipv" {
   source               = "./modules/canary"
-  count                = var.environment == "production" ? 0 : 1
   environment          = var.environment
   artifact_s3_location = "s3://${aws_s3_bucket.smoketest_artefact_bucket.bucket}"
   artefact_bucket_arn  = aws_s3_bucket.smoketest_artefact_bucket.arn


### PR DESCRIPTION
## What?
- Enable IPV/P2 journey smoke test in prod

## Why?
- Changes have now been tested in integration

## Related PRs
- Enables: https://github.com/alphagov/di-authentication-smoke-tests/pull/76 and https://github.com/alphagov/di-authentication-smoke-tests/pull/74 in production
