### PR TITLE
AUT-835: Remove module block on smoke tests in prod

### DIFF
--- a/ci/terraform/modules/canary/canary.tf
+++ b/ci/terraform/modules/canary/canary.tf
@@ -1,7 +1,5 @@
 
 resource "aws_synthetics_canary" "smoke_tester_canary" {
-
-  count                = var.environment == "production" ? 0 : 1
   artifact_s3_location = var.artifact_s3_location
 
   execution_role_arn = aws_iam_role.smoke_tester_role[0].arn


### PR DESCRIPTION
## What?
- Remove module block on smoke tests in prod

## Why?
- This should allow IPV/P2 smoke test to deploy

## Related PRs
- Extends: https://github.com/alphagov/di-authentication-smoke-tests/pull/79
