### PR TITLE
AUT-981 - Give canary permissions to write to the correct cloudwatch location

### DIFF
--- a/ci/terraform/modules/canary/policies.tf
+++ b/ci/terraform/modules/canary/policies.tf
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "canary_execution" {
     ]
 
     resources = [
-      "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/cwsyn-${var.canary_name}-*",
+      "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/cwsyn-${local.smoke_tester_name}-*",
     ]
   }
 


### PR DESCRIPTION
## What?

- Give canary permissions to write to the correct cloudwatch location

## Why?

- It had permissions to log to `/aws/lambda/cwsyn-smoke-ipv-*` but it actually needs permission to log to `/aws/lambda/cwsyn-integration-smoke-ipv-*` which now includes the environment
