### PR TITLE
AUT-835: (Correction) Remove prod smoke test module block

### DIFF
--- a/ci/terraform/modules/canary/parameters.tf
+++ b/ci/terraform/modules/canary/parameters.tf
@@ -116,7 +116,7 @@ resource "aws_ssm_parameter" "ipv_smoke_test_phone" {
 }
 
 resource "aws_ssm_parameter" "basic_auth_username" {
-  count  = var.environment == "production" ? 0 : 1
+  count  = 1
   name   = "${var.environment}-${var.canary_name}-basicauth-username"
   type   = "SecureString"
   value  = var.basic_auth_username
@@ -126,7 +126,7 @@ resource "aws_ssm_parameter" "basic_auth_username" {
 }
 
 resource "aws_ssm_parameter" "basic_auth_password" {
-  count  = var.environment == "production" ? 0 : 1
+  count  = 1
   name   = "${var.environment}-${var.canary_name}-basicauth-password"
   type   = "SecureString"
   value  = var.basic_auth_password

--- a/ci/terraform/modules/canary/policies.tf
+++ b/ci/terraform/modules/canary/policies.tf
@@ -144,7 +144,7 @@ data "aws_iam_policy_document" "parameter_policy" {
 }
 
 data "aws_iam_policy_document" "basic_auth_parameter_policy" {
-  count = var.environment == "production" ? 0 : 1
+  count = 1
   statement {
     sid    = "AllowGetParameters"
     effect = "Allow"
@@ -174,7 +174,7 @@ data "aws_iam_policy_document" "basic_auth_parameter_policy" {
 }
 
 resource "aws_iam_policy" "basic_auth_parameter_policy" {
-  count       = var.environment == "production" ? 0 : 1
+  count       = 1
   policy      = data.aws_iam_policy_document.basic_auth_parameter_policy[0].json
   name_prefix = "${var.environment}-${var.canary_name}-basic-auth-parameter-store-policy"
 }

--- a/ci/terraform/modules/canary/roles.tf
+++ b/ci/terraform/modules/canary/roles.tf
@@ -1,30 +1,30 @@
 
 resource "aws_iam_role" "smoke_tester_role" {
-  count              = var.environment == "production" ? 0 : 1
+  count              = 1
   assume_role_policy = data.aws_iam_policy_document.lambda_can_assume_policy.json
   name               = "${var.environment}-${var.canary_name}-canary-execution-role"
 }
 
 resource "aws_iam_role_policy_attachment" "canary_execution" {
-  count      = var.environment == "production" ? 0 : 1
+  count      = 1
   policy_arn = aws_iam_policy.canary_execution.arn
   role       = aws_iam_role.smoke_tester_role[0].name
 }
 
 resource "aws_iam_role_policy_attachment" "sms_bucket_policy" {
-  count      = var.environment == "production" ? 0 : 1
+  count      = 1
   policy_arn = aws_iam_policy.sms_bucket_policy.arn
   role       = aws_iam_role.smoke_tester_role[0].name
 }
 
 resource "aws_iam_role_policy_attachment" "parameter_policy" {
-  count      = var.environment == "production" ? 0 : 1
+  count      = 1
   policy_arn = aws_iam_policy.parameter_policy.arn
   role       = aws_iam_role.smoke_tester_role[0].name
 }
 
 resource "aws_iam_role_policy_attachment" "basic_auth_parameter_policy" {
-  count      = var.environment == "production" ? 0 : 1
+  count      = 1
   policy_arn = aws_iam_policy.basic_auth_parameter_policy[0].arn
   role       = aws_iam_role.smoke_tester_role[0].name
 }


### PR DESCRIPTION
## What?
- Remove a number of `count = {conditional on environment}` in canary base module

## Why?
- Amends 58117071cc3c4380e60cb758b727758fe4144455
- Terraform module contained many references to production with zero counts associated
- These break deployment in prod

## Related PRs
-Amends: https://github.com/alphagov/di-authentication-smoke-tests/pull/81
