### PR TITLE
AUT-829: Re-enable create account smoke test in integration

### DIFF
--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -18,6 +18,7 @@ params:
   BASIC_AUTH_USERNAME: ((basic-auth-username-integration))
   BASIC_AUTH_PASSWORD: ((basic-auth-password-integration))
   SMOKETESTER_CREATE_ACCOUNT_USERNAME: ((smoke-tester-create-account-username-integration))
+  SMOKETESTER_CREATE_ACCOUNT_PHONE: ((smoke-tester-create-account-phone-integration))
   TEST_SERVICES_API_HOSTNAME: ((test-services-api-hostname-integration))
   TEST_SERVICES_API_KEY: ((test-services-api-key-integration))
   SYNTHETICS_USER_DELETE_PATH: ((synthetics-user-delete-path-integration))
@@ -80,6 +81,7 @@ run:
         -var "alerts_code_s3_key=${ALERT_CODE_S3_KEY}" \
         -var "heartbeat_code_s3_key=${HEARTBEAT_CODE_S3_KEY}" \
         -var "username_create_account=${SMOKETESTER_CREATE_ACCOUNT_USERNAME}" \
+        -var "phone_create_account=${SMOKETESTER_CREATE_ACCOUNT_PHONE}" \
         -var "test-services-api-hostname=${TEST_SERVICES_API_HOSTNAME}" \
         -var "test-services-api-key=${TEST_SERVICES_API_KEY}" \
         -var "synthetics-user-delete-path=${SYNTHETICS_USER_DELETE_PATH}" \

--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -1,7 +1,7 @@
 
 module "canary_create_account" {
   source               = "./modules/canary"
-  count                = contains(["production", "integration"], var.environment) ? 0 : 1
+  count                = contains(["production"], var.environment) ? 0 : 1
   environment          = var.environment
   artifact_s3_location = "s3://${aws_s3_bucket.smoketest_artefact_bucket.bucket}"
   artefact_bucket_arn  = aws_s3_bucket.smoketest_artefact_bucket.arn
@@ -28,7 +28,7 @@ module "canary_create_account" {
   synthetics-user-delete-path = var.synthetics-user-delete-path
   username                    = var.username_create_account
   password                    = var.password
-  phone                       = var.phone
+  phone                       = var.phone_create_account
   ipv_smoke_test_phone        = var.ipv_smoke_test_phone
   basic_auth_username         = var.basic_auth_username
   basic_auth_password         = var.basic_auth_password

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -133,6 +133,10 @@ variable "username_create_account" {
   type = string
 }
 
+variable "phone_create_account" {
+  type = string
+}
+
 variable "synthetics-user-delete-path" {
   type = string
 }


### PR DESCRIPTION

## What?

Re-enable create account smoke test in integration.
Add separate variable for phone number so all smoke tests can use a different number.


## Why?

The smoke test was deleted in order to release the ipv smoke test to both integration and production.  Way is now free to release the create account smoke test.

Each smoke test must use a separate phone number in order to receive sms otp.

## Related PRs

#77 
