### PR TITLE
AUT-981 - Use name_prefix instead of name for aws_cloudwatch_log_group

### DIFF
--- a/ci/terraform/modules/canary/canary.tf
+++ b/ci/terraform/modules/canary/canary.tf
@@ -39,7 +39,7 @@ resource "aws_synthetics_canary" "smoke_tester_canary" {
 resource "aws_cloudwatch_log_group" "canary_log_group" {
   count = var.environment == "production" ? 0 : 1
 
-  name              = "/aws/lambda/cwsyn-${aws_synthetics_canary.smoke_tester_canary[0].name}"
+  name_prefix       = "/aws/lambda/cwsyn-${aws_synthetics_canary.smoke_tester_canary[0].name}-"
   tags              = local.default_tags
   kms_key_id        = var.cloudwatch_key_arn
   retention_in_days = var.cloudwatch_log_retention


### PR DESCRIPTION
## What?

- Use name_prefix instead of name for aws_cloudwatch_log_group

## Why?

- AWS create a cloudwatch log group for us with the name  /aws/lambda/cwsyn-MyCanaryName-randomId. We don't know what the random ID will be but we do know the prefix of the name so use that instead
