### PR TITLE
AUT-829: Deploy the create account smoke test to production

### DIFF
--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -1,7 +1,7 @@
 
 module "canary_create_account" {
   source               = "./modules/canary"
-  count                = contains(["production"], var.environment) ? 0 : 1
+  count                = 1
   environment          = var.environment
   artifact_s3_location = "s3://${aws_s3_bucket.smoketest_artefact_bucket.bucket}"
   artefact_bucket_arn  = aws_s3_bucket.smoketest_artefact_bucket.arn


### PR DESCRIPTION
## What?

Deploy the create account smoke test to production.

Requires the test-services-api to also be deployed in production, and changes to the smoke tests pipeline.

## Why?

The test is running in integration but not in production.

## Related PRs

