### PR TITLE
AUT-981 - Correctly name the aws cloudwatch log group

### DIFF
--- a/ci/terraform/modules/canary/alarm.tf
+++ b/ci/terraform/modules/canary/alarm.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p1" {
   treat_missing_data  = "notBreaching"
 
   dimensions = {
-    CanaryName = aws_synthetics_canary.smoke_tester_canary[0].name
+    CanaryName = aws_synthetics_canary.smoke_tester_canary.name
   }
 
   alarm_description = "GOV.UK Sign in - ${local.smoke_tester_name} (create account smoke test) P1 alarm"
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p2" {
   treat_missing_data  = "notBreaching"
 
   dimensions = {
-    CanaryName = aws_synthetics_canary.smoke_tester_canary[0].name
+    CanaryName = aws_synthetics_canary.smoke_tester_canary.name
   }
 
   alarm_description = "GOV.UK Sign in - ${local.smoke_tester_name} (create account smoke test) P2 alarm"

--- a/ci/terraform/modules/canary/parameters.tf
+++ b/ci/terraform/modules/canary/parameters.tf
@@ -116,7 +116,6 @@ resource "aws_ssm_parameter" "ipv_smoke_test_phone" {
 }
 
 resource "aws_ssm_parameter" "basic_auth_username" {
-  count  = 1
   name   = "${var.environment}-${var.canary_name}-basicauth-username"
   type   = "SecureString"
   value  = var.basic_auth_username
@@ -126,7 +125,6 @@ resource "aws_ssm_parameter" "basic_auth_username" {
 }
 
 resource "aws_ssm_parameter" "basic_auth_password" {
-  count  = 1
   name   = "${var.environment}-${var.canary_name}-basicauth-password"
   type   = "SecureString"
   value  = var.basic_auth_password

--- a/ci/terraform/modules/canary/policies.tf
+++ b/ci/terraform/modules/canary/policies.tf
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "canary_execution" {
     ]
 
     resources = [
-      "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/cwsyn-${local.smoke_tester_name}-*",
+      "arn:aws:logs:*:*:*",
     ]
   }
 
@@ -75,6 +75,10 @@ data "aws_iam_policy_document" "canary_execution" {
 resource "aws_iam_policy" "canary_execution" {
   policy      = data.aws_iam_policy_document.canary_execution.json
   name_prefix = "${var.environment}-${var.canary_name}-canary-execution-policy"
+
+  depends_on = [
+    data.aws_iam_policy_document.canary_execution
+  ]
 }
 
 data "aws_iam_policy_document" "sms_bucket_policy" {
@@ -98,6 +102,10 @@ data "aws_iam_policy_document" "sms_bucket_policy" {
 resource "aws_iam_policy" "sms_bucket_policy" {
   policy      = data.aws_iam_policy_document.sms_bucket_policy.json
   name_prefix = "${var.environment}-${var.canary_name}-canary-sms-bucket-policy"
+
+  depends_on = [
+    data.aws_iam_policy_document.sms_bucket_policy
+  ]
 }
 
 data "aws_iam_policy_document" "parameter_policy" {
@@ -144,7 +152,6 @@ data "aws_iam_policy_document" "parameter_policy" {
 }
 
 data "aws_iam_policy_document" "basic_auth_parameter_policy" {
-  count = 1
   statement {
     sid    = "AllowGetParameters"
     effect = "Allow"
@@ -154,8 +161,8 @@ data "aws_iam_policy_document" "basic_auth_parameter_policy" {
     ]
 
     resources = [
-      aws_ssm_parameter.basic_auth_password[0].arn,
-      aws_ssm_parameter.basic_auth_username[0].arn,
+      aws_ssm_parameter.basic_auth_password.arn,
+      aws_ssm_parameter.basic_auth_username.arn,
     ]
   }
   statement {
@@ -174,12 +181,19 @@ data "aws_iam_policy_document" "basic_auth_parameter_policy" {
 }
 
 resource "aws_iam_policy" "basic_auth_parameter_policy" {
-  count       = 1
-  policy      = data.aws_iam_policy_document.basic_auth_parameter_policy[0].json
+  policy      = data.aws_iam_policy_document.basic_auth_parameter_policy.json
   name_prefix = "${var.environment}-${var.canary_name}-basic-auth-parameter-store-policy"
+
+  depends_on = [
+    data.aws_iam_policy_document.basic_auth_parameter_policy
+  ]
 }
 
 resource "aws_iam_policy" "parameter_policy" {
   policy      = data.aws_iam_policy_document.parameter_policy.json
   name_prefix = "${var.environment}-${var.canary_name}-parameter-store-policy"
+
+  depends_on = [
+    data.aws_iam_policy_document.parameter_policy
+  ]
 }

--- a/ci/terraform/modules/canary/roles.tf
+++ b/ci/terraform/modules/canary/roles.tf
@@ -1,30 +1,49 @@
 
 resource "aws_iam_role" "smoke_tester_role" {
-  count              = 1
   assume_role_policy = data.aws_iam_policy_document.lambda_can_assume_policy.json
   name               = "${var.environment}-${var.canary_name}-canary-execution-role"
+
+  depends_on = [
+    data.aws_iam_policy_document.lambda_can_assume_policy
+  ]
 }
 
 resource "aws_iam_role_policy_attachment" "canary_execution" {
-  count      = 1
   policy_arn = aws_iam_policy.canary_execution.arn
-  role       = aws_iam_role.smoke_tester_role[0].name
+  role       = aws_iam_role.smoke_tester_role.name
+
+  depends_on = [
+    aws_iam_policy.canary_execution,
+    aws_iam_role.smoke_tester_role
+  ]
 }
 
 resource "aws_iam_role_policy_attachment" "sms_bucket_policy" {
-  count      = 1
   policy_arn = aws_iam_policy.sms_bucket_policy.arn
-  role       = aws_iam_role.smoke_tester_role[0].name
+  role       = aws_iam_role.smoke_tester_role.name
+
+  depends_on = [
+    aws_iam_policy.sms_bucket_policy,
+    aws_iam_role.smoke_tester_role
+  ]
 }
 
 resource "aws_iam_role_policy_attachment" "parameter_policy" {
-  count      = 1
   policy_arn = aws_iam_policy.parameter_policy.arn
-  role       = aws_iam_role.smoke_tester_role[0].name
+  role       = aws_iam_role.smoke_tester_role.name
+
+  depends_on = [
+    aws_iam_policy.parameter_policy,
+    aws_iam_role.smoke_tester_role
+  ]
 }
 
 resource "aws_iam_role_policy_attachment" "basic_auth_parameter_policy" {
-  count      = 1
-  policy_arn = aws_iam_policy.basic_auth_parameter_policy[0].arn
-  role       = aws_iam_role.smoke_tester_role[0].name
+  policy_arn = aws_iam_policy.basic_auth_parameter_policy.arn
+  role       = aws_iam_role.smoke_tester_role.name
+
+  depends_on = [
+    aws_iam_policy.basic_auth_parameter_policy,
+    aws_iam_role.smoke_tester_role
+  ]
 }


### PR DESCRIPTION

## What?

- Correctly name the aws cloudwatch log group

## Why?

- AWS canary automatically creates a cloudwatch log group and attached the random ID to this. To ensure that the AWS canary uses our log group, we need to create one via terraform with the same expected name.
- There is no easy way to get the random ID, so we need to take the engine_arn which is outputted from the aws canary and split it on a colon. This will give us the ID as expected
- Remove count on the canary module as we can place the count on the canaries that use the module instead
- Add some depends on to ensures that the terraform dependencies are created in the correct order
