### PR TITLE
AUT-981 - Create sign in smoke test using the canary module

### DIFF
--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -32,6 +32,8 @@ params:
   SIGNED_CODE_S3_BUCKET: ((di-auth-lambda-signed-bucket))
   IPV_SMOKE_TEST_PHONE_NUMBER: ((ipv-smoke-test-phone-number-integration))
   IPV_SMOKE_TEST_USERNAME: ((ipv-smoke-test-username-integration))
+  SIGN_IN_SMOKE_TEST_PHONE_NUMBER: ((sign-in-smoke-test-phone-number-integration))
+  SIGN_IN_SMOKE_TEST_USERNAME: ((sign-in-smoke-test-username-integration))
 
 inputs:
   - name: src
@@ -87,6 +89,8 @@ run:
         -var "synthetics-user-delete-path=${SYNTHETICS_USER_DELETE_PATH}" \
         -var "ipv_smoke_test_phone=${IPV_SMOKE_TEST_PHONE_NUMBER}" \
         -var "ipv_smoke_test_username=${IPV_SMOKE_TEST_USERNAME}" \
+        -var "sign_in_smoke_test_phone=${SIGN_IN_SMOKE_TEST_PHONE_NUMBER}" \
+        -var "sign_in_smoke_test_username=${SIGN_IN_SMOKE_TEST_USERNAME}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
         -var-file "${DEPLOY_ENVIRONMENT}-stub-clients.tfvars" \
 

--- a/ci/terraform/canary-sign-in.tf
+++ b/ci/terraform/canary-sign-in.tf
@@ -1,0 +1,45 @@
+module "canary_sign_in" {
+  source               = "./modules/canary"
+  environment          = var.environment
+  artifact_s3_location = "s3://${aws_s3_bucket.smoketest_artefact_bucket.bucket}"
+  artefact_bucket_arn  = aws_s3_bucket.smoketest_artefact_bucket.arn
+
+  slack_hook_uri      = var.slack_hook_uri
+  sms_bucket_name     = local.sms_bucket_name
+  sms_bucket_name_arn = local.sms_bucket_name_arn
+
+  canary_handler = "canary-sign-in.handler"
+  canary_name    = "smoke-sign-in"
+
+  canary_source_bucket     = aws_s3_bucket_object.canary_source.bucket
+  canary_source_key        = aws_s3_bucket_object.canary_source.key
+  canary_source_version_id = aws_s3_bucket_object.canary_source.version_id
+
+  sns_topic_pagerduty_p1_alerts_arn = aws_sns_topic.pagerduty_p1_alerts.arn
+  sns_topic_pagerduty_p2_alerts_arn = aws_sns_topic.pagerduty_p2_alerts.arn
+  sns_topic_slack_alerts_arn        = data.aws_sns_topic.slack_events.arn
+  create_account_smoke_test         = false
+  metric_alarms_enabled             = var.sign_in_metric_alarm_enabled
+  heartbeat_ping_enabled            = var.sign_in_heartbeat_ping_enabled
+
+  username            = var.sign_in_smoke_test_username
+  password            = var.password
+  phone               = var.sign_in_smoke_test_phone
+  basic_auth_username = var.basic_auth_username
+  basic_auth_password = var.basic_auth_password
+  client_id           = random_string.stub_rp_client_id[0].result
+  client_base_url     = var.client_base_url
+  client_private_key  = tls_private_key.stub_rp_client_private_key[0].private_key_pem
+  issuer_base_url     = var.issuer_base_url
+
+  # the test will run Mon-Fri, between 1000-1700 every 3 minutes
+  smoke_test_cron_expression = "0/03 10-17 ? * MON-FRI *"
+
+  cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention = 1
+  logging_endpoint_arns    = var.logging_endpoint_arns
+
+  depends_on = [
+    aws_lambda_function.cronitor_ping_lambda
+  ]
+}

--- a/ci/terraform/integration-overrides.tfvars
+++ b/ci/terraform/integration-overrides.tfvars
@@ -5,6 +5,10 @@ logging_endpoint_arns = [
 ]
 
 create_account_metric_alarm_enabled   = true
-ipv_sign_in_metric_alarm_enabled      = true
 create_account_heartbeat_ping_enabled = false
-ipv_sign_in_heartbeat_ping_enabled    = false
+
+ipv_sign_in_metric_alarm_enabled   = true
+ipv_sign_in_heartbeat_ping_enabled = false
+
+sign_in_metric_alarm_enabled   = false
+sign_in_heartbeat_ping_enabled = false

--- a/ci/terraform/production-overrides.tfvars
+++ b/ci/terraform/production-overrides.tfvars
@@ -5,6 +5,10 @@ logging_endpoint_arns = [
 ]
 
 create_account_metric_alarm_enabled   = false
-ipv_sign_in_metric_alarm_enabled      = false
 create_account_heartbeat_ping_enabled = false
-ipv_sign_in_heartbeat_ping_enabled    = false
+
+ipv_sign_in_metric_alarm_enabled   = false
+ipv_sign_in_heartbeat_ping_enabled = false
+
+sign_in_metric_alarm_enabled   = false
+sign_in_heartbeat_ping_enabled = false

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -21,10 +21,14 @@ basic_auth_password                   = "p"
 integration_basic_auth_username       = ""
 integration_basic_auth_password       = ""
 slack_hook_uri                        = "some-slack-uri"
+sign_in_smoke_test_username           = ""
+sign_in_smoke_test_phone              = ""
 create_account_metric_alarm_enabled   = false
 ipv_sign_in_metric_alarm_enabled      = false
 create_account_heartbeat_ping_enabled = false
 ipv_sign_in_heartbeat_ping_enabled    = false
+sign_in_metric_alarm_enabled          = false
+sign_in_heartbeat_ping_enabled        = false
 
 
 alerts_code_s3_key                      = "di-monitoring-utils/alerts.zip/sandpit-smoketest"

--- a/ci/terraform/user.tf
+++ b/ci/terraform/user.tf
@@ -98,6 +98,69 @@ resource "aws_dynamodb_table_item" "user_profile" {
   })
 }
 
+resource "aws_dynamodb_table_item" "user_credential_sign_in_smoke_test" {
+  table_name = data.aws_dynamodb_table.user_credential_table.name
+  hash_key   = data.aws_dynamodb_table.user_credential_table.hash_key
+  item = jsonencode({
+    "Email" = {
+      "S" = var.sign_in_smoke_test_username
+    },
+    "Updated" = {
+      "S" = local.create_date
+    },
+    "SubjectID" = {
+      "S" = random_string.subject_id.result
+    },
+    "Password" = {
+      "S" = var.hashed_password
+    },
+    "Created" = {
+      "S" = formatdate("YYYY-MM-DD'T'hh:mm:ss.000000", time_static.create_date.rfc3339)
+    }
+  })
+}
+
+resource "aws_dynamodb_table_item" "user_profile_sign_in_smoke_test" {
+  table_name = data.aws_dynamodb_table.user_profile_table.name
+  hash_key   = data.aws_dynamodb_table.user_profile_table.hash_key
+  item = jsonencode({
+    "Email" = {
+      "S" = var.sign_in_smoke_test_username
+    },
+    "EmailVerified" = {
+      "N" = "1"
+    },
+    "PhoneNumberVerified" = {
+      "N" = "1"
+    },
+    "SubjectID" = {
+      "S" = random_string.subject_id.result
+    },
+    "PhoneNumber" = {
+      "S" = var.sign_in_smoke_test_phone
+    },
+    "PublicSubjectID" = {
+      "S" = random_string.public_subject_id.result
+    },
+    "termsAndConditions" = {
+      "M" = {
+        "version" = {
+          "S" = var.terms_and_conditions_version
+        },
+        "timestamp" = {
+          "S" = local.create_date
+        }
+      }
+    },
+    "Updated" = {
+      "S" = local.create_date
+    },
+    "Created" = {
+      "S" = local.create_date
+    }
+  })
+}
+
 resource "aws_dynamodb_table_item" "user_profile_ipv_smoke_test" {
   table_name = data.aws_dynamodb_table.user_profile_table.name
   hash_key   = data.aws_dynamodb_table.user_profile_table.hash_key

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -48,6 +48,10 @@ variable "phone" {
   type = string
 }
 
+variable "sign_in_smoke_test_phone" {
+  type = string
+}
+
 variable "ipv_smoke_test_phone" {
   type = string
 }
@@ -69,6 +73,10 @@ variable "smoke_test_rate_minutes" {
 }
 
 variable "username" {
+  type = string
+}
+
+variable "sign_in_smoke_test_username" {
   type = string
 }
 
@@ -198,10 +206,18 @@ variable "create_account_metric_alarm_enabled" {
   type = bool
 }
 
+variable "sign_in_metric_alarm_enabled" {
+  type = bool
+}
+
 variable "ipv_sign_in_heartbeat_ping_enabled" {
   type = bool
 }
 
 variable "create_account_heartbeat_ping_enabled" {
+  type = bool
+}
+
+variable "sign_in_heartbeat_ping_enabled" {
   type = bool
 }

--- a/src/canary-sign-in.js
+++ b/src/canary-sign-in.js
@@ -1,0 +1,147 @@
+const log = require("SyntheticsLogger");
+const synthetics = require("Synthetics");
+const { getParameter, getOTPCode, emptyOtpBucket } = require("./aws");
+const { startClient } = require("./client");
+
+const CANARY_NAME = synthetics.getCanaryName();
+const SYNTHETICS_CONFIG = synthetics.getConfiguration();
+
+SYNTHETICS_CONFIG.setConfig({
+  screenshotOnStepStart: true,
+  screenshotOnStepSuccess: true,
+  screenshotOnStepFailure: true,
+});
+
+const basicCustomEntryPoint = async () => {
+  log.info("Running smoke tests");
+
+  const bucketName = await getParameter("bucket");
+  const email = await getParameter("username");
+  const phoneNumber = await getParameter("phone");
+  const clientBaseUrl = await getParameter("client-base-url");
+  const clientId = await getParameter("client-id");
+  const issuerBaseURL = await getParameter("issuer-base-url");
+  const clientPrivateKey = await getParameter("client-private-key");
+
+  const server = await startClient(
+    3031,
+    "openid email phone",
+    clientId,
+    clientBaseUrl,
+    issuerBaseURL,
+    clientPrivateKey
+  );
+
+  log.info("Empty OTP code bucket");
+  await emptyOtpBucket(bucketName, phoneNumber);
+
+  let page = await synthetics.getPage();
+  const navigationPromise = page.waitForNavigation({
+    waitUntil: "networkidle0",
+  });
+
+  if (CANARY_NAME.includes("integration")) {
+    log.info("Running against INTEGRATION environment");
+
+    const basicAuthUsername = await getParameter("basicauth-username");
+    const basicAuthPassword = await getParameter("basicauth-password");
+
+    await page.authenticate({
+      username: basicAuthUsername,
+      password: basicAuthPassword,
+    });
+  }
+
+  await synthetics.executeStep("Launch Client", async () => {
+    await page.goto(clientBaseUrl, {
+      waitUntil: "domcontentloaded",
+    });
+  });
+
+  await page.setViewport({ width: 1864, height: 1096 });
+
+  await navigationPromise;
+
+  await synthetics.executeStep("Click sign in", async () => {
+    await page.waitForSelector("#main-content #sign-in-link");
+    await page.click("#main-content #sign-in-link");
+  });
+
+  await navigationPromise;
+
+  await synthetics.executeStep("Enter email", async () => {
+    await page.waitForSelector(".govuk-grid-row #email");
+    await page.type(".govuk-grid-row #email", email);
+  });
+
+  await synthetics.executeStep("Click continue", async () => {
+    await page.waitForSelector(
+      "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button"
+    );
+    await page.click(
+      "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button"
+    );
+  });
+
+  await navigationPromise;
+
+  await synthetics.executeStep("Enter password", async () => {
+    await page.waitForSelector(".govuk-grid-row #password");
+    const password = await getParameter("password");
+    await page.type(".govuk-grid-row #password", password);
+  });
+
+  await synthetics.executeStep("Click continue", async () => {
+    await page.waitForSelector(
+      "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button"
+    );
+    await page.click(
+      "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button"
+    );
+  });
+
+  await navigationPromise;
+
+  await synthetics.executeStep("Enter OTP code", async () => {
+    await page.waitForSelector(".govuk-grid-row #code");
+
+    const otpCode = await getOTPCode(phoneNumber, bucketName);
+
+    await page.type(".govuk-grid-row #code", otpCode);
+  });
+
+  await synthetics.executeStep("Click continue", async () => {
+    await page.waitForSelector(
+      "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button"
+    );
+    await Promise.all([
+      page.click(
+        "#main-content > .govuk-grid-row > .govuk-grid-column-two-thirds > form > .govuk-button"
+      ),
+      page.waitForNavigation(),
+    ]);
+  });
+
+  await synthetics.executeStep("Microclient user-info", async () => {
+    await page.content();
+
+    const userInfo = await page.evaluate(() => {
+      // eslint-disable-next-line no-undef
+      return JSON.parse(document.querySelector("body").innerText);
+    });
+
+    const hasReachedUserInfo = userInfo.email === email;
+
+    if (!hasReachedUserInfo) {
+      server.close();
+      throw "Failed smoke test";
+    }
+  });
+
+  server.close();
+  return "success";
+};
+
+module.exports.handler = async () => {
+  return await basicCustomEntryPoint();
+};


### PR DESCRIPTION
## What?

- Create a sign in smoke test to use the canary terraform module. 

## Why?

- This will mean we can reuse a lot of the terraform and eventually deprecate the existing sign in smoke test.
