### PR TITLE
AUT-981 - Fix pipeline

### DIFF
--- a/ci/terraform/canary-sign-in.tf
+++ b/ci/terraform/canary-sign-in.tf
@@ -9,7 +9,7 @@ module "canary_sign_in" {
   sms_bucket_name_arn = local.sms_bucket_name_arn
 
   canary_handler = "canary-sign-in.handler"
-  canary_name    = "smoke-sign-in"
+  canary_name    = "smoke-in"
 
   canary_source_bucket     = aws_s3_bucket_object.canary_source.bucket
   canary_source_key        = aws_s3_bucket_object.canary_source.key

--- a/ci/terraform/parameters.tf
+++ b/ci/terraform/parameters.tf
@@ -119,6 +119,14 @@ resource "aws_ssm_parameter" "client_private_key" {
   tags = local.default_tags
 }
 
+resource "aws_ssm_parameter" "smoke_test_client_id" {
+  name  = "${var.environment}-smoke-test-client-id"
+  type  = "String"
+  value = random_string.stub_rp_client_id[0].result
+
+  tags = local.default_tags
+}
+
 resource "aws_ssm_parameter" "client_base_url" {
   name  = "${local.smoke_tester_name}-client-base-url"
   type  = "String"


### PR DESCRIPTION
## What?

- Add parameter back in which is actually being used
- Reduce size of canary name to make it less than 21 chars

## Why?

- Parameter is read in by the WAF so the client id is allowed 
- Canary name is too long when prefixed with the environment 