### PR TITLE
AUT-981 - Create random_string resource for each user and each subject

### DIFF
--- a/ci/terraform/user-ipv-sign-in.tf
+++ b/ci/terraform/user-ipv-sign-in.tf
@@ -1,0 +1,81 @@
+resource "random_string" "subject_id_ipv_sign_in" {
+  keepers = {
+    username = var.username
+  }
+  lower   = true
+  upper   = true
+  special = false
+  number  = true
+  length  = 32
+}
+
+resource "random_string" "public_subject_id_ipv_sign_in" {
+  lower   = true
+  upper   = true
+  special = false
+  number  = true
+  length  = 32
+}
+
+resource "aws_dynamodb_table_item" "user_profile_ipv_smoke_test" {
+  table_name = data.aws_dynamodb_table.user_profile_table.name
+  hash_key   = data.aws_dynamodb_table.user_profile_table.hash_key
+  item = jsonencode({
+    "Email" = {
+      "S" = var.ipv_smoke_test_username
+    },
+    "EmailVerified" = {
+      "N" = "1"
+    },
+    "PhoneNumberVerified" = {
+      "N" = "1"
+    },
+    "SubjectID" = {
+      "S" = random_string.subject_id_ipv_sign_in.result
+    },
+    "PhoneNumber" = {
+      "S" = var.ipv_smoke_test_phone
+    },
+    "PublicSubjectID" = {
+      "S" = random_string.public_subject_id_ipv_sign_in.result
+    },
+    "termsAndConditions" = {
+      "M" = {
+        "version" = {
+          "S" = var.terms_and_conditions_version
+        },
+        "timestamp" = {
+          "S" = local.create_date
+        }
+      }
+    },
+    "Updated" = {
+      "S" = local.create_date
+    },
+    "Created" = {
+      "S" = local.create_date
+    }
+  })
+}
+
+resource "aws_dynamodb_table_item" "user_credential_ipv_smoke_test" {
+  table_name = data.aws_dynamodb_table.user_credential_table.name
+  hash_key   = data.aws_dynamodb_table.user_credential_table.hash_key
+  item = jsonencode({
+    "Email" = {
+      "S" = var.ipv_smoke_test_username
+    },
+    "Updated" = {
+      "S" = local.create_date
+    },
+    "SubjectID" = {
+      "S" = random_string.subject_id_ipv_sign_in.result
+    },
+    "Password" = {
+      "S" = var.hashed_password
+    },
+    "Created" = {
+      "S" = formatdate("YYYY-MM-DD'T'hh:mm:ss.000000", time_static.create_date.rfc3339)
+    }
+  })
+}

--- a/ci/terraform/user-sign-in.tf
+++ b/ci/terraform/user-sign-in.tf
@@ -1,22 +1,4 @@
-data "aws_dynamodb_table" "user_credential_table" {
-  name = "${var.environment}-user-credentials"
-}
-
-data "aws_dynamodb_table" "user_profile_table" {
-  name = "${var.environment}-user-profile"
-}
-
-resource "time_static" "create_date" {
-  triggers = {
-    username = var.username
-  }
-}
-
-locals {
-  create_date = formatdate("YYYY-MM-DD'T'hh:mm:ss.000000", time_static.create_date.rfc3339)
-}
-
-resource "random_string" "subject_id" {
+resource "random_string" "subject_id_sign_in" {
   keepers = {
     username = var.username
   }
@@ -27,7 +9,7 @@ resource "random_string" "subject_id" {
   length  = 32
 }
 
-resource "random_string" "public_subject_id" {
+resource "random_string" "public_subject_id_sign_in" {
   lower   = true
   upper   = true
   special = false
@@ -35,18 +17,18 @@ resource "random_string" "public_subject_id" {
   length  = 32
 }
 
-resource "aws_dynamodb_table_item" "user_credential" {
+resource "aws_dynamodb_table_item" "user_credential_sign_in_smoke_test" {
   table_name = data.aws_dynamodb_table.user_credential_table.name
   hash_key   = data.aws_dynamodb_table.user_credential_table.hash_key
   item = jsonencode({
     "Email" = {
-      "S" = var.username
+      "S" = var.sign_in_smoke_test_username
     },
     "Updated" = {
       "S" = local.create_date
     },
     "SubjectID" = {
-      "S" = random_string.subject_id.result
+      "S" = random_string.subject_id_sign_in.result
     },
     "Password" = {
       "S" = var.hashed_password
@@ -57,12 +39,12 @@ resource "aws_dynamodb_table_item" "user_credential" {
   })
 }
 
-resource "aws_dynamodb_table_item" "user_profile" {
+resource "aws_dynamodb_table_item" "user_profile_sign_in_smoke_test" {
   table_name = data.aws_dynamodb_table.user_profile_table.name
   hash_key   = data.aws_dynamodb_table.user_profile_table.hash_key
   item = jsonencode({
     "Email" = {
-      "S" = var.username
+      "S" = var.sign_in_smoke_test_username
     },
     "EmailVerified" = {
       "N" = "1"
@@ -71,13 +53,13 @@ resource "aws_dynamodb_table_item" "user_profile" {
       "N" = "1"
     },
     "SubjectID" = {
-      "S" = random_string.subject_id.result
+      "S" = random_string.subject_id_sign_in.result
     },
     "PhoneNumber" = {
-      "S" = var.phone
+      "S" = var.sign_in_smoke_test_phone
     },
     "PublicSubjectID" = {
-      "S" = random_string.public_subject_id.result
+      "S" = random_string.public_subject_id_sign_in.result
     },
     "termsAndConditions" = {
       "M" = {


### PR DESCRIPTION
## What?

- Create random_string resource for each user and each subject

## Why?

- All 3 users were reusing the same subject_id resource which was causing all users to have the same subject ID. To avoid this split the users out into separate files and allocate them their own random_string resource for both the subject_id and public_subject_id.