### PR TITLE
AUT-981 - Make the sign in smoke test rate dynamic per environment 

### DIFF
--- a/ci/terraform/canary-sign-in.tf
+++ b/ci/terraform/canary-sign-in.tf
@@ -32,8 +32,7 @@ module "canary_sign_in" {
   client_private_key  = tls_private_key.stub_rp_client_private_key[0].private_key_pem
   issuer_base_url     = var.issuer_base_url
 
-  # the test will run Mon-Fri, between 1000-1700 every 3 minutes
-  smoke_test_cron_expression = "0/03 10-17 ? * MON-FRI *"
+  smoke_test_cron_expression = var.smoke_test_cron_expression
 
   cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention = 1

--- a/ci/terraform/integration-overrides.tfvars
+++ b/ci/terraform/integration-overrides.tfvars
@@ -10,5 +10,8 @@ create_account_heartbeat_ping_enabled = false
 ipv_sign_in_metric_alarm_enabled   = true
 ipv_sign_in_heartbeat_ping_enabled = false
 
-sign_in_metric_alarm_enabled   = false
+sign_in_metric_alarm_enabled   = true
 sign_in_heartbeat_ping_enabled = false
+
+#This will run the smoke tests every 3 minutes between 09:00 - 17:00 Mon - Fri
+smoke_test_cron_expression = "0/03 09-17 ? * MON-FRI *"

--- a/ci/terraform/production-overrides.tfvars
+++ b/ci/terraform/production-overrides.tfvars
@@ -12,3 +12,6 @@ ipv_sign_in_heartbeat_ping_enabled = false
 
 sign_in_metric_alarm_enabled   = false
 sign_in_heartbeat_ping_enabled = false
+
+#This will run the smoke tests every 3 minutes 24/7
+smoke_test_cron_expression = "0/03 * * * ? *"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -29,7 +29,7 @@ create_account_heartbeat_ping_enabled = false
 ipv_sign_in_heartbeat_ping_enabled    = false
 sign_in_metric_alarm_enabled          = false
 sign_in_heartbeat_ping_enabled        = false
-
+smoke_test_cron_expression            = "0/03 09-17 ? * MON-FRI *"
 
 alerts_code_s3_key                      = "di-monitoring-utils/alerts.zip/sandpit-smoketest"
 heartbeat_code_s3_key                   = "di-monitoring-utils/heartbeat.zip/sandpit-smoketest"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -221,3 +221,7 @@ variable "create_account_heartbeat_ping_enabled" {
 variable "sign_in_heartbeat_ping_enabled" {
   type = bool
 }
+
+variable "smoke_test_cron_expression" {
+  type = string
+}


### PR DESCRIPTION

## What?

- Make the sign in smoke test rate dynamic per environment 
- Set on the sign in alarm for Integration only
- Increase the rate for the new production sign in smoke test to run every 3 mins 24/7

## Why?

- We have different SLAs per environment so make the cron expression which runs the sign in smoke test dynamic per environment
- Set the sign in smoke test to run the smoke tests every 3 minutes between 09:00 - 17:00 Mon - Fri for Integration
- Set the sign in smoke test to run the the smoke tests every 3 minutes 24/7 for Production
- Adjust the cron expression as per https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
- Turn on the alerts for this lambda for Integration

