### PR TITLE
AUT-981 - Switch on Cronitor for new sign in smoke test for Integration

### DIFF
--- a/ci/terraform/heartbeat.tf
+++ b/ci/terraform/heartbeat.tf
@@ -65,6 +65,7 @@ resource "aws_lambda_function" "cronitor_ping_lambda" {
 }
 
 resource "aws_cloudwatch_event_rule" "cronitor_event" {
+  count      = var.sign_in_heartbeat_ping_enabled ? 0 : 1
   name       = "${var.environment}-cronitor-rule"
   is_enabled = true
   event_pattern = jsonencode({
@@ -86,15 +87,17 @@ resource "aws_cloudwatch_event_rule" "cronitor_event" {
 }
 
 resource "aws_cloudwatch_event_target" "cronitor_event_target" {
-  arn  = aws_lambda_function.cronitor_ping_lambda.arn
-  rule = aws_cloudwatch_event_rule.cronitor_event.name
+  count = var.sign_in_heartbeat_ping_enabled ? 0 : 1
+  arn   = aws_lambda_function.cronitor_ping_lambda.arn
+  rule  = aws_cloudwatch_event_rule.cronitor_event[0].name
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_trigger_cronitor_lambda" {
+  count               = var.sign_in_heartbeat_ping_enabled ? 0 : 1
   statement_id_prefix = "AllowExecutionFromCloudWatchScheduleRule"
 
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.cronitor_ping_lambda.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.cronitor_event.arn
+  source_arn    = aws_cloudwatch_event_rule.cronitor_event[0].arn
 }

--- a/ci/terraform/integration-overrides.tfvars
+++ b/ci/terraform/integration-overrides.tfvars
@@ -11,7 +11,7 @@ ipv_sign_in_metric_alarm_enabled   = true
 ipv_sign_in_heartbeat_ping_enabled = false
 
 sign_in_metric_alarm_enabled   = true
-sign_in_heartbeat_ping_enabled = false
+sign_in_heartbeat_ping_enabled = true
 
 #This will run the smoke tests every 3 minutes between 09:00 - 17:00 Mon - Fri
 smoke_test_cron_expression = "0/03 09-17 ? * MON-FRI *"


### PR DESCRIPTION
## What?

- Switch on Cronitor for new sign in smoke test for Integration
- Add a flag so when cronitor is switched on the new smoke test, it is switched off on the old sign in smoke test. 

## Why?

- This will make migration easier

