### PR TITLE
AUT-981 - Enable Sign In module smoke test alarms and cronitor in Production

### DIFF
--- a/ci/terraform/alarm.tf
+++ b/ci/terraform/alarm.tf
@@ -1,5 +1,6 @@
 
 resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p1" {
+  count               = var.sign_in_metric_alarm_enabled ? 0 : 1
   alarm_name          = "${local.smoke_tester_name}-metric-alarm_p1"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -20,6 +21,7 @@ resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p1" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p2" {
+  count               = var.sign_in_metric_alarm_enabled ? 0 : 1
   alarm_name          = "${local.smoke_tester_name}-metric-alarm_p2"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "3"

--- a/ci/terraform/production-overrides.tfvars
+++ b/ci/terraform/production-overrides.tfvars
@@ -10,8 +10,8 @@ create_account_heartbeat_ping_enabled = false
 ipv_sign_in_metric_alarm_enabled   = false
 ipv_sign_in_heartbeat_ping_enabled = false
 
-sign_in_metric_alarm_enabled   = false
-sign_in_heartbeat_ping_enabled = false
+sign_in_metric_alarm_enabled   = true
+sign_in_heartbeat_ping_enabled = true
 
 #This will run the smoke tests every 3 minutes 24/7
 smoke_test_cron_expression = "0/03 * * * ? *"


### PR DESCRIPTION
## What?

- Disable original Sign In smoke test alarm and cronitor for Production as it is being replaced with the new module smoke test

## Why?

- The old sign in smoke test will be removed soon in favour of the new sign in smoke test which uses the canary module