### PR TITLE
AUT-923: Empty create account smoke test phone otp bucket

### DIFF
--- a/src/canary-create-account.js
+++ b/src/canary-create-account.js
@@ -69,6 +69,7 @@ const basicCustomEntryPoint = async () => {
 
   log.info("Empty OTP code bucket");
   await emptyOtpBucket(bucketName, email);
+  await emptyOtpBucket(bucketName, phoneNumber);
 
   let page = await synthetics.getPage();
   const navigationPromise = page.waitForNavigation({


### PR DESCRIPTION
## What?

Empty create account smoke test phone otp bucket.

## Why?

Prevent exceptions when writing to the bucket during tests.

Currently seeing 'Exception thrown when writing to S3 bucket' for the phone number for this test.  This error is not seen for other smoke tests.
