### PR TITLE
GitHub Actions to build and push modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Build modules
+env:
+  DEPLOYER_ROLE: arn:aws:iam::114407264696:role/deployers/github-actions-publish-to-s3-for-code-signing
+  SOURCE_BUCKET: di-auth-lambda-source-20220215170204376700000003
+  DESTINATION_BUCKET: di-auth-lambda-signed-20220215170204376200000002
+  SIGNING_PROFILE: di_auth_lambda_signing_20220215170204371800000001
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ env.DEPLOYER_ROLE }}
+        aws-region: eu-west-2
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: 'yarn'
+    
+    - name: Install dependencies
+      run: yarn install --production
+    
+    - name: Build smoke tests
+      run: yarn build
+    
+    - name: Upload smoke tests to source bucket
+      working-directory: dist
+      run: |
+        S3_RESPONSE=`aws s3api put-object \
+          --bucket $SOURCE_BUCKET \
+          --key canary/${{ github.sha }}.zip \
+          --body canary.zip`
+        VERSION=`echo $S3_RESPONSE | jq .VersionId -r`
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+    
+    - name: Start signing job for smoke tests
+      run: |
+        aws signer start-signing-job \
+          --profile-name "${SIGNING_PROFILE}" \
+          --source "s3={bucketName=${SOURCE_BUCKET},key=canary/${{ github.sha }}.zip,version=$VERSION}" \
+          --destination "s3={bucketName=${DESTINATION_BUCKET},prefix=signed-canary-${{ github.sha }}-}"


### PR DESCRIPTION
## What?

GitHub Actions to build and push modules:
- builds each module, packaging as a zip
- uploads built artifact to S3
- runs signing job against artifact

## Why?

Supporting efforts to move off Concourse

## Related PRs

Depends on https://github.com/alphagov/di-infrastructure/pull/471
