### PR TITLE
AUT-1116: Sign in button instead of link

### DIFF
--- a/src/canary-sign-in-with-ipv.js
+++ b/src/canary-sign-in-with-ipv.js
@@ -100,8 +100,8 @@ const basicCustomEntryPoint = async () => {
   await navigationPromise;
 
   await synthetics.executeStep("Click sign in", async () => {
-    await page.waitForSelector("#main-content #sign-in-link");
-    await page.click("#main-content #sign-in-link");
+    await page.waitForSelector("#main-content #sign-in-button");
+    await page.click("#main-content #sign-in-button");
   });
 
   await navigationPromise;

--- a/src/canary-sign-in.js
+++ b/src/canary-sign-in.js
@@ -63,8 +63,8 @@ const basicCustomEntryPoint = async () => {
   await navigationPromise;
 
   await synthetics.executeStep("Click sign in", async () => {
-    await page.waitForSelector("#main-content #sign-in-link");
-    await page.click("#main-content #sign-in-link");
+    await page.waitForSelector("#main-content #sign-in-button");
+    await page.click("#main-content #sign-in-button");
   });
 
   await navigationPromise;


### PR DESCRIPTION

## What?

Sign in button instead of link

## Why?

The sign in link has changed to a button.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/951