### PR TITLE
AUT-1134: Remove Photo ID execution steps as not required in pre-auth journey

### DIFF
--- a/src/canary-sign-in-with-ipv.js
+++ b/src/canary-sign-in-with-ipv.js
@@ -85,20 +85,6 @@ const basicCustomEntryPoint = async () => {
 
   await navigationPromise;
 
-  await synthetics.executeStep("Select yes to having photo ID", async () => {
-    await page.waitForSelector("#havePhotoId");
-    await page.click("#havePhotoId");
-  });
-
-  await navigationPromise;
-
-  await synthetics.executeStep("Click continue", async () => {
-    await page.waitForSelector("#form-tracking > button");
-    await page.click("#form-tracking > button");
-  });
-
-  await navigationPromise;
-
   await synthetics.executeStep("Click sign in", async () => {
     await page.waitForSelector("#main-content #sign-in-button");
     await page.click("#main-content #sign-in-button");


### PR DESCRIPTION
## What?

Remove the Photo ID execution step as it's no longer included in pre-auth journey

## Why?

Photo ID Screener not necessary due to low user usage (user's selecting No - I don't have a Photo ID)

## Related PRs

[Changes in frontend app](https://github.com/alphagov/di-authentication-frontend/pull/962)
