### PR TITLE
BAU - Adjust smoke test threshold to 2 failures in 10 minutes

### DIFF
--- a/ci/terraform/modules/canary/alarm.tf
+++ b/ci/terraform/modules/canary/alarm.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "smoke_tester_metric_alarm_p1" {
   namespace           = "CloudWatchSynthetics"
   period              = "600"
   statistic           = "Sum"
-  threshold           = "3"
+  threshold           = "2"
   treat_missing_data  = "notBreaching"
 
   dimensions = {


### PR DESCRIPTION
## What?

 - Adjust smoke test threshold to 2 failures in 10 minutes

## Why?

- To ensure we are alerted quickly for any downtime that occurs 
