### PR TITLE
AUT-1211 - Make Node server shutdown after every Smoke Test run

### DIFF
--- a/src/canary-create-account.js
+++ b/src/canary-create-account.js
@@ -7,6 +7,8 @@ const crypto = require("crypto");
 const CANARY_NAME = synthetics.getCanaryName();
 const SYNTHETICS_CONFIG = synthetics.getConfiguration();
 
+let server;
+
 SYNTHETICS_CONFIG.setConfig({
   screenshotOnStepStart: false,
   screenshotOnStepSuccess: false,
@@ -58,7 +60,7 @@ const basicCustomEntryPoint = async () => {
     throw "Smoke Test failed due to Fire Drill";
   }
 
-  const server = await startClient(
+  server = await startClient(
     3031,
     "openid email phone",
     clientId,
@@ -266,15 +268,20 @@ const basicCustomEntryPoint = async () => {
     const hasReachedUserInfo = userInfo.email === email;
 
     if (!hasReachedUserInfo) {
-      server.close();
       throw "Failed smoke test";
     }
   });
 
-  server.close();
   return "success";
 };
 
 module.exports.handler = async () => {
-  return await basicCustomEntryPoint();
+  try {
+    return await basicCustomEntryPoint();
+  } catch (err) {
+    log.error(err);
+    throw err;
+  } finally {
+    if (server) server.close();
+  }
 };

--- a/src/canary-sign-in-with-ipv.js
+++ b/src/canary-sign-in-with-ipv.js
@@ -166,6 +166,7 @@ module.exports.handler = async () => {
     return await basicCustomEntryPoint();
   } catch (err) {
     log.error(err);
+    throw err;
   } finally {
     if (server) server.close();
   }


### PR DESCRIPTION
## What?
- Ensure that we always shut down the node server after every run by adding in a finally block similar to what we have on the IPV smoke test

## Why?

- We are seeing situations where a smoke test is failing and the next smoke test fails to run because the previous smoke test has not shut down so there is a process still running on the port. The error we are seeing is `No test result returned.listen EADDRINUSE: address already in use 0.0.0.0:3031`



