### PR TITLE
AUT-1211 - Adjust times of smoke test runs

### DIFF
--- a/ci/terraform/canary-sign-in-with-ipv.tf
+++ b/ci/terraform/canary-sign-in-with-ipv.tf
@@ -32,8 +32,8 @@ module "canary_sign_in_with_ipv" {
   client_private_key  = tls_private_key.stub_rp_client_private_key[0].private_key_pem
   issuer_base_url     = var.use_integration_env_for_sign_in_journey ? var.integration_issuer_base_url : var.issuer_base_url
 
-  # the test will run Mon-Fri, between 1000-1700 every 5 minutes
-  smoke_test_cron_expression = "0/05 10-17 ? * MON-FRI *"
+  # the test will run Mon-Fri, between 0800-1700 (UTC) every 5 minutes
+  smoke_test_cron_expression = "0/05 08-17 ? * MON-FRI *"
 
   cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention = 1

--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -36,8 +36,8 @@ module "canary_create_account" {
   client_private_key          = tls_private_key.stub_rp_client_private_key[0].private_key_pem
   issuer_base_url             = var.issuer_base_url
 
-  # the test will run Mon-Fri, between 1000-1700 every 3 minutes
-  smoke_test_cron_expression = "0/03 10-17 ? * MON-FRI *"
+  # the test will run Mon-Fri, between 0800-1700 (UTC) every 3 minutes
+  smoke_test_cron_expression = "0/03 08-17 ? * MON-FRI *"
 
   cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention = 1

--- a/ci/terraform/integration-overrides.tfvars
+++ b/ci/terraform/integration-overrides.tfvars
@@ -13,5 +13,5 @@ ipv_sign_in_heartbeat_ping_enabled = false
 sign_in_metric_alarm_enabled   = true
 sign_in_heartbeat_ping_enabled = true
 
-#This will run the smoke tests every 3 minutes between 09:00 - 17:00 Mon - Fri
-smoke_test_cron_expression = "0/03 09-17 ? * MON-FRI *"
+#This will run the smoke tests every 3 minutes between 09:00 - 17:00 (UTC) Mon - Fri
+smoke_test_cron_expression = "0/03 08-17 ? * MON-FRI *"


### PR DESCRIPTION
## What?

 - Adjust times of smoke test runs

## Why?

- The cron expression is in UTC which means the current IPV/Create account smoke test do not start until 11:00am. Eventually these will run 24/7 but for now adjust the times so that they start earlier

