### PR TITLE
BAU: Bump Ts&Cs version to reflect new privacy policy

### DIFF
--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -98,7 +98,7 @@ variable "integration_basic_auth_password" {
 }
 
 variable "terms_and_conditions_version" {
-  default = "1.1"
+  default = "1.2"
 }
 
 variable "code_s3_bucket" {


### PR DESCRIPTION
## What?

Bump Ts&Cs version to reflect new privacy policy.

This needs to be rolled out after the api change has deployed, pause the smoke tests during the integration and prod deployments.

## Why?

The privacy policy has been updated.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2917
