### PR TITLE
BAU: Bump puppeteer to the latest version 4.0

### DIFF
--- a/ci/terraform/modules/canary/canary.tf
+++ b/ci/terraform/modules/canary/canary.tf
@@ -5,7 +5,7 @@ resource "aws_synthetics_canary" "smoke_tester_canary" {
   execution_role_arn = aws_iam_role.smoke_tester_role.arn
   handler            = var.canary_handler
   name               = local.smoke_tester_name
-  runtime_version    = "syn-nodejs-puppeteer-3.9"
+  runtime_version    = "syn-nodejs-puppeteer-4.0"
   start_canary       = true
 
   s3_bucket  = var.canary_source_bucket


### PR DESCRIPTION
## What?

Bump puppeteer to the latest version 4.0.

## Why?

Keep the version current so that it doesn't expire unexpectedly.
