### PR TITLE
BAU: Switch off Create Account smoke test

### DIFF
--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -38,6 +38,7 @@ module "canary_create_account" {
 
   # the test will run Mon-Fri, between 0800-1700 (UTC) every 3 minutes
   smoke_test_cron_expression = "0/03 08-17 ? * MON-FRI *"
+  start_canary               = false
 
   cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention = 1

--- a/ci/terraform/modules/canary/canary.tf
+++ b/ci/terraform/modules/canary/canary.tf
@@ -6,7 +6,7 @@ resource "aws_synthetics_canary" "smoke_tester_canary" {
   handler            = var.canary_handler
   name               = local.smoke_tester_name
   runtime_version    = "syn-nodejs-puppeteer-4.0"
-  start_canary       = true
+  start_canary       = var.start_canary
 
   s3_bucket  = var.canary_source_bucket
   s3_key     = var.canary_source_key

--- a/ci/terraform/modules/canary/variables.tf
+++ b/ci/terraform/modules/canary/variables.tf
@@ -143,3 +143,8 @@ variable "logging_endpoint_arns" {
   default     = []
   description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
 }
+
+variable "start_canary" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION

## What?

Switch off Create Account smoke test.

## Why?

Pending fix for intermittent failures.

## Related

https://govukverify.atlassian.net/browse/AUT-1333
