### PR TITLE
BAU: Turn on PagerDuty alerting for Production IPV handoff smoke tests

### DIFF
--- a/ci/terraform/production-overrides.tfvars
+++ b/ci/terraform/production-overrides.tfvars
@@ -7,7 +7,7 @@ logging_endpoint_arns = [
 create_account_metric_alarm_enabled   = false
 create_account_heartbeat_ping_enabled = false
 
-ipv_sign_in_metric_alarm_enabled   = false
+ipv_sign_in_metric_alarm_enabled   = true
 ipv_sign_in_heartbeat_ping_enabled = false
 
 sign_in_metric_alarm_enabled   = true


### PR DESCRIPTION
## What?
- Turn on PagerDuty alerting for Production IPV handoff smoke tests
- This includes Slack alerting via PagerDuty integration

## Why?
- Gives quicker alerting capability where breaking changes may be introduced in sign-in journey that break IPV Core handoff
