### PR TITLE
BAU - Run the IPV P1 smoke test 24/7

### DIFF
--- a/ci/terraform/canary-sign-in-with-ipv.tf
+++ b/ci/terraform/canary-sign-in-with-ipv.tf
@@ -32,8 +32,7 @@ module "canary_sign_in_with_ipv" {
   client_private_key  = tls_private_key.stub_rp_client_private_key[0].private_key_pem
   issuer_base_url     = var.use_integration_env_for_sign_in_journey ? var.integration_issuer_base_url : var.issuer_base_url
 
-  # the test will run Mon-Fri, between 0800-1700 (UTC) every 5 minutes
-  smoke_test_cron_expression = "0/05 08-17 ? * MON-FRI *"
+  smoke_test_cron_expression = var.smoke_test_cron_expression
 
   cloudwatch_key_arn       = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention = 1


### PR DESCRIPTION
## What?

 - Run the IPV P1 smoke test 24/7

## Why?

- As it's a P1 smoke test, we need to be alerted out of hours as well as in hours if there are any issues.
