### PR TITLE
BAU: Update ipv landing page title

### DIFF
--- a/src/canary-sign-in-with-ipv.js
+++ b/src/canary-sign-in-with-ipv.js
@@ -152,7 +152,7 @@ const basicCustomEntryPoint = async () => {
 
     const hasReachedIPV =
       (await page.title()) ===
-      "Tell us if you have one of the following types of photo ID";
+      "Tell us if you have one of the following types of photo ID – GOV.UK";
 
     if (!hasReachedIPV) {
       throw "Failed smoke test";


### PR DESCRIPTION

## What?

Update ipv landing page title.

## Why?

To fix failing smoke test due to the page content changing.
