### PR TITLE
Rename variables to use underscores

### DIFF
--- a/ci/terraform/create-account.tf
+++ b/ci/terraform/create-account.tf
@@ -24,9 +24,9 @@ module "canary_create_account" {
   metric_alarms_enabled             = var.create_account_metric_alarm_enabled
   heartbeat_ping_enabled            = var.create_account_heartbeat_ping_enabled
 
-  test-services-api-key       = var.test-services-api-key
-  test-services-api-hostname  = var.test-services-api-hostname
-  synthetics-user-delete-path = var.synthetics-user-delete-path
+  test_services_api_key       = var.test_services_api_key
+  test_services_api_hostname  = var.test_services_api_hostname
+  synthetics_user_delete_path = var.synthetics_user_delete_path
   username                    = var.username_create_account
   phone                       = var.phone_create_account
   basic_auth_username         = var.basic_auth_username

--- a/ci/terraform/modules/canary/parameters.tf
+++ b/ci/terraform/modules/canary/parameters.tf
@@ -46,29 +46,29 @@ resource "aws_ssm_parameter" "fire_drill" {
   tags = local.default_tags
 }
 
-resource "aws_ssm_parameter" "test-services-api-key" {
+resource "aws_ssm_parameter" "test_services_api_key" {
   count = var.create_account_smoke_test ? 1 : 0
-  name  = "${var.environment}-${var.canary_name}-test-services-api-key"
+  name  = "${var.environment}-${var.canary_name}-test_services_api_key"
   type  = "String"
-  value = var.test-services-api-key
+  value = var.test_services_api_key
 
   tags = local.default_tags
 }
 
-resource "aws_ssm_parameter" "test-services-api-hostname" {
+resource "aws_ssm_parameter" "test_services_api_hostname" {
   count = var.create_account_smoke_test ? 1 : 0
-  name  = "${var.environment}-${var.canary_name}-test-services-api-hostname"
+  name  = "${var.environment}-${var.canary_name}-test_services_api_hostname"
   type  = "String"
-  value = var.test-services-api-hostname
+  value = var.test_services_api_hostname
 
   tags = local.default_tags
 }
 
-resource "aws_ssm_parameter" "synthetics-user-delete-path" {
+resource "aws_ssm_parameter" "synthetics_user_delete_path" {
   count = var.create_account_smoke_test ? 1 : 0
-  name  = "${var.environment}-${var.canary_name}-synthetics-user-delete-path"
+  name  = "${var.environment}-${var.canary_name}-synthetics_user_delete_path"
   type  = "String"
-  value = var.synthetics-user-delete-path
+  value = var.synthetics_user_delete_path
 
   tags = local.default_tags
 }

--- a/ci/terraform/modules/canary/policies.tf
+++ b/ci/terraform/modules/canary/policies.tf
@@ -120,9 +120,9 @@ data "aws_iam_policy_document" "create_parameter_policy" {
 
     resources = [
       aws_ssm_parameter.fire_drill.arn,
-      aws_ssm_parameter.test-services-api-key[0].arn,
-      aws_ssm_parameter.test-services-api-hostname[0].arn,
-      aws_ssm_parameter.synthetics-user-delete-path[0].arn,
+      aws_ssm_parameter.test_services_api_key[0].arn,
+      aws_ssm_parameter.test_services_api_hostname[0].arn,
+      aws_ssm_parameter.synthetics_user_delete_path[0].arn,
       aws_ssm_parameter.phone.arn,
       aws_ssm_parameter.sms_bucket.arn,
       aws_ssm_parameter.username.arn,

--- a/ci/terraform/modules/canary/variables.tf
+++ b/ci/terraform/modules/canary/variables.tf
@@ -64,17 +64,17 @@ variable "fire_drill" {
   default = "0"
 }
 
-variable "synthetics-user-delete-path" {
+variable "synthetics_user_delete_path" {
   type    = string
   default = null
 }
 
-variable "test-services-api-key" {
+variable "test_services_api_key" {
   type    = string
   default = null
 }
 
-variable "test-services-api-hostname" {
+variable "test_services_api_hostname" {
   type    = string
   default = null
 }

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -131,15 +131,15 @@ variable "phone_create_account" {
   type = string
 }
 
-variable "synthetics-user-delete-path" {
+variable "synthetics_user_delete_path" {
   type = string
 }
 
-variable "test-services-api-key" {
+variable "test_services_api_key" {
   type = string
 }
 
-variable "test-services-api-hostname" {
+variable "test_services_api_hostname" {
   type = string
 }
 


### PR DESCRIPTION
## What?

Rename variables to use underscores.

## Why?

New pipeline doesn't support variables with hyphens (weird bash issue).