### PR TITLE
Rename SSM parameters to original values

### DIFF
--- a/ci/terraform/modules/canary/parameters.tf
+++ b/ci/terraform/modules/canary/parameters.tf
@@ -46,27 +46,27 @@ resource "aws_ssm_parameter" "fire_drill" {
   tags = local.default_tags
 }
 
-resource "aws_ssm_parameter" "test_services_api_key" {
+resource "aws_ssm_parameter" "test-services-api-key" {
   count = var.create_account_smoke_test ? 1 : 0
-  name  = "${var.environment}-${var.canary_name}-test_services_api_key"
+  name  = "${var.environment}-${var.canary_name}-test-services-api-key"
   type  = "String"
   value = var.test_services_api_key
 
   tags = local.default_tags
 }
 
-resource "aws_ssm_parameter" "test_services_api_hostname" {
+resource "aws_ssm_parameter" "test-services-api-hostname" {
   count = var.create_account_smoke_test ? 1 : 0
-  name  = "${var.environment}-${var.canary_name}-test_services_api_hostname"
+  name  = "${var.environment}-${var.canary_name}-test-services-api-hostname"
   type  = "String"
   value = var.test_services_api_hostname
 
   tags = local.default_tags
 }
 
-resource "aws_ssm_parameter" "synthetics_user_delete_path" {
+resource "aws_ssm_parameter" "synthetics-user-delete-path" {
   count = var.create_account_smoke_test ? 1 : 0
-  name  = "${var.environment}-${var.canary_name}-synthetics_user_delete_path"
+  name  = "${var.environment}-${var.canary_name}-synthetics-user-delete-path"
   type  = "String"
   value = var.synthetics_user_delete_path
 

--- a/ci/terraform/modules/canary/policies.tf
+++ b/ci/terraform/modules/canary/policies.tf
@@ -120,9 +120,9 @@ data "aws_iam_policy_document" "create_parameter_policy" {
 
     resources = [
       aws_ssm_parameter.fire_drill.arn,
-      aws_ssm_parameter.test_services_api_key[0].arn,
-      aws_ssm_parameter.test_services_api_hostname[0].arn,
-      aws_ssm_parameter.synthetics_user_delete_path[0].arn,
+      aws_ssm_parameter.test-services-api-key[0].arn,
+      aws_ssm_parameter.test-services-api-hostname[0].arn,
+      aws_ssm_parameter.synthetics-user-delete-path[0].arn,
       aws_ssm_parameter.phone.arn,
       aws_ssm_parameter.sms_bucket.arn,
       aws_ssm_parameter.username.arn,


### PR DESCRIPTION
## What?

Renames:
test_services_api_key -> test-services-api-key
test_services_api_hostname -> test-services-api-hostname
synthetics_user_delete_path -> synthetics-user-delete-path

## Why?

Likely to introduce a bug if terraform deletes the SSM parameters while in use.