### PR TITLE
AUT-1505 - Upgrade Canary version to the latest

### DIFF
--- a/ci/terraform/modules/canary/canary.tf
+++ b/ci/terraform/modules/canary/canary.tf
@@ -5,7 +5,7 @@ resource "aws_synthetics_canary" "smoke_tester_canary" {
   execution_role_arn = aws_iam_role.smoke_tester_role.arn
   handler            = var.canary_handler
   name               = local.smoke_tester_name
-  runtime_version    = "syn-nodejs-puppeteer-4.0"
+  runtime_version    = "syn-nodejs-puppeteer-5.1"
   start_canary       = var.start_canary
 
   s3_bucket  = var.canary_source_bucket


### PR DESCRIPTION
## What?

- Upgrade Canary version to the latest

## Why?

- 5.1 is the latest runtime so we should use it


